### PR TITLE
feat: 여행 API 피그마 스펙 반영 (이미지, 인원수, 상태 필드 추가)

### DIFF
--- a/src/main/java/com/retrip/trip/application/in/request/TripCreateRequest.java
+++ b/src/main/java/com/retrip/trip/application/in/request/TripCreateRequest.java
@@ -29,6 +29,9 @@ public record TripCreateRequest(
         @NotNull
         String title,
 
+        @Schema(description = "여행 대표 이미지 URL")
+        String imageUrl,
+
         @Schema(description = "여행 설명", example = "파리, 런던, 로마를 여행하는 일정입니다.")
         String description,
 
@@ -61,6 +64,7 @@ public record TripCreateRequest(
                 memberId,
                 locationId,
                 new TripTitle(title),
+                imageUrl,
                 new TripDescription(description),
                 new TripPeriod(start, end),
                 open,
@@ -76,12 +80,14 @@ public record TripCreateRequest(
                 memberId,
                 locationId,
                 new TripTitle(title),
+                imageUrl,
                 new TripDescription(description),
                 new TripPeriod(start, end),
                 open,
                 maxParticipants,
                 hashTags,
-                category
+                category,
+                TripStatus.RECRUITING
         );
     }
 }

--- a/src/main/java/com/retrip/trip/application/in/response/TripDetailResponse.java
+++ b/src/main/java/com/retrip/trip/application/in/response/TripDetailResponse.java
@@ -40,9 +40,11 @@ public record TripDetailResponse(
         @Schema(description = "여행 상태 명")
         String tripStatusName,
 
-        // TODO: 해당 부분은 아직 Trip 쪽에서 구현이 안되어있어서 추후 해당 응답에 값 담을 예정
         @Schema(description = "여행지")
         String tripLocation,
+
+        @Schema(description = "여행 대표 이미지 URL")
+        String imageUrl,
 
         @Schema(description = "여행 소개")
         String description,
@@ -65,7 +67,8 @@ public record TripDetailResponse(
                 .maxParticipantCount(trip.getTripParticipants().getMaxParticipants())
                 .tripStatus(trip.getStatus())
                 .tripStatusName(trip.getStatus().getViewName())
-                .tripLocation("") //TODO : 구현 되면 채워 넣을 예정
+                .tripLocation("") // TODO : Location 구현 시 채울 예정
+                .imageUrl(trip.getImageUrl())
                 .description(trip.getDescription().getValue())
                 .hashTags(trip.getHashTags().getHashTagNames())
                 .participants(TripParticipantResponse.toList(trip.getTripParticipants().getValues()))
@@ -74,7 +77,6 @@ public record TripDetailResponse(
 
     @Builder
     public record TripParticipantResponse (
-
             @Schema(description = "여행 참가자 고유 id")
             UUID participantId,
 

--- a/src/main/java/com/retrip/trip/application/in/response/TripResponse.java
+++ b/src/main/java/com/retrip/trip/application/in/response/TripResponse.java
@@ -2,6 +2,7 @@ package com.retrip.trip.application.in.response;
 
 import com.retrip.trip.domain.entity.Trip;
 import com.retrip.trip.domain.entity.TripHashTag;
+import com.retrip.trip.domain.vo.TripStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDate;
@@ -9,7 +10,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import lombok.AllArgsConstructor;
 
 @Schema(description = "여행 목록 Response")
 public record TripResponse(
@@ -22,11 +22,26 @@ public record TripResponse(
         @Schema(description = "목적지 ID")
         UUID destinationId,
 
+        @Schema(description = "목적지 명 (예: 파리, 제주)")
+        String destinationName, // TODO: 추후 QueryDSL Join으로 데이터 채우기 구현 필요
+
+        @Schema(description = "여행 대표 이미지 URL")
+        String imageUrl,
+
+        @Schema(description = "여행 상태")
+        TripStatus status,
+
         @Schema(description = "여행 시작 날짜")
         LocalDate start,
 
         @Schema(description = "여행 종료 날짜")
         LocalDate end,
+
+        @Schema(description = "현재 참가자 수")
+        int currentParticipantCount,
+
+        @Schema(description = "최대 참가자 수")
+        int maxParticipantCount,
 
         @Schema(description = "여행 공개 여부")
         boolean open,
@@ -46,12 +61,16 @@ public record TripResponse(
                         trip.getId(),
                         trip.getTitle().getValue(),
                         trip.getDestinationId(),
+                        "", // destinationName: 현재 Location 정보가 없으므로 빈 값 또는 추후 구현
+                        trip.getImageUrl(),
+                        trip.getStatus(),
                         trip.getPeriod().getStart(),
                         trip.getPeriod().getEnd(),
+                        trip.getTripParticipants().getCurrentCount(),
+                        trip.getTripParticipants().getMaxParticipants(),
                         trip.isOpen(),
                         tags.getOrDefault(trip.getId(), List.of())
                 ))
                 .toList();
-
     }
 }

--- a/src/main/java/com/retrip/trip/domain/entity/Trip.java
+++ b/src/main/java/com/retrip/trip/domain/entity/Trip.java
@@ -42,15 +42,20 @@ public class Trip extends BaseEntity {
     @Embedded
     private TripDescription description;
 
+    @Column(name = "image_url")
+    private String imageUrl;
+
     private boolean open;
 
     @Embedded
     private TripPassword tripPassword;
 
     @Column(name = "status", length = 50, nullable = false)
+    @Enumerated(EnumType.STRING)
     private TripStatus status;
 
     @Column(name = "category", length = 50, nullable = false)
+    @Enumerated(EnumType.STRING)
     private TripCategory category;
 
     @Embedded
@@ -72,17 +77,20 @@ public class Trip extends BaseEntity {
             UUID memberId,
             UUID destinationId,
             TripTitle title,
+            String imageUrl,
             TripDescription description,
             TripPeriod period,
             boolean open,
             int maxParticipants,
             List<String> hashTags,
             TripCategory category,
-            TripStatus status) {
+            TripStatus status
+    ) {
         Trip trip = Trip.builder()
                 .id(UUID.randomUUID())
                 .destinationId(destinationId)
                 .title(title)
+                .imageUrl(imageUrl)
                 .description(description)
                 .period(period)
                 .open(open)
@@ -98,22 +106,25 @@ public class Trip extends BaseEntity {
             UUID leaderId,
             UUID destinationId,
             TripTitle title,
+            String imageUrl,
             TripDescription description,
             TripPeriod period,
             boolean open,
             int maxParticipants,
             List<String> hashTags,
-            TripCategory category
+            TripCategory category,
+            TripStatus status
     ) {
         Trip trip = Trip.builder()
                 .id(UUID.randomUUID())
                 .destinationId(destinationId)
                 .title(title)
+                .imageUrl(imageUrl)
                 .description(description)
                 .period(period)
                 .open(open)
                 .category(category)
-                .status(TripStatus.RECRUITING)
+                .status(status)
                 .build();
         trip.itineraries = new Itineraries(trip, period);
         trip.tripParticipants = new TripParticipants(leaderId, trip, maxParticipants);
@@ -125,9 +136,7 @@ public class Trip extends BaseEntity {
         this.tripParticipants.addParticipant(participant);
     }
 
-    public void updatePeriod(
-            TripPeriod period,
-            @NotNull UUID memberId) {
+    public void updatePeriod(TripPeriod period, @NotNull UUID memberId) {
         if (!tripParticipants.updatableByLeader(memberId)) {
             throw new PeriodUpdateFailedException();
         }

--- a/src/test/java/com/retrip/trip/application/in/TripServiceTest.java
+++ b/src/test/java/com/retrip/trip/application/in/TripServiceTest.java
@@ -42,8 +42,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
 
 class TripServiceTest extends BaseTripServiceTest {
+
+    private static final String TEST_IMAGE_URL = "https://test-image.com/default.jpg";
+
     private Trip createTestTripWithParticipants(TripStatus status) {
         Trip trip = createTestTrip("테스트 여행", "여행 설명", TripCategory.DOMESTIC, status);
         trip.addParticipant(TripParticipant.createTripParticipant(정수_ID, trip));
@@ -52,7 +56,8 @@ class TripServiceTest extends BaseTripServiceTest {
     }
 
     private Trip createTestTrip(String title, String description, TripCategory category, TripStatus status) {
-        Trip trip = TripFixture.createTestTrip(memberId, title, description, category, status);
+        Trip trip = TripFixture.createTestTrip(memberId, title, description, category);
+        ReflectionTestUtils.setField(trip, "status", status);
         return tripRepository.save(trip);
     }
 
@@ -73,6 +78,7 @@ class TripServiceTest extends BaseTripServiceTest {
                         memberId,
                         locationId,
                         "속초 여행 멤버 구함",
+                        "https://k.kakaocdn.net/dn/image.jpg",
                         "속초 여행은 이렇게이렇게 갈겁니다~",
                         LocalDate.now().plusDays(1),
                         LocalDate.now().plusDays(5),
@@ -89,15 +95,16 @@ class TripServiceTest extends BaseTripServiceTest {
 
     @Test
     void 여행_목록을_조회한다() {
-        tripRepository.save(TripFixture.createTestTrip(memberId, "속초 여행 맴버 구함", "속초 여행은 이렇게이렇게 갈겁니다~", TripCategory.DOMESTIC, TripStatus.RECRUITING));
-        tripRepository.save(TripFixture.createTestTrip(memberId, "대구 여행 멤버 구함", "대구 여행은 이렇게이렇게 갈겁니다~", TripCategory.DOMESTIC, TripStatus.RECRUITING));
-        tripRepository.save(TripFixture.createTestTrip(memberId, "부산 여행 멤버 구함", "부산 여행은 이렇게이렇게 갈겁니다~", TripCategory.DOMESTIC, TripStatus.RECRUITING));
+        // TripFixture 호출 시 status 파라미터 관련 문제 해결을 위해 createTestTrip 헬퍼 메서드 사용 (위에서 수정함)
+        tripRepository.save(createTestTrip("속초 여행 맴버 구함", "속초 여행은 이렇게이렇게 갈겁니다~", TripCategory.DOMESTIC, TripStatus.RECRUITING));
+        tripRepository.save(createTestTrip("대구 여행 멤버 구함", "대구 여행은 이렇게이렇게 갈겁니다~", TripCategory.DOMESTIC, TripStatus.RECRUITING));
+        tripRepository.save(createTestTrip("부산 여행 멤버 구함", "부산 여행은 이렇게이렇게 갈겁니다~", TripCategory.DOMESTIC, TripStatus.RECRUITING));
+
         Page<TripResponse> trips = tripService.getTrips(PageRequest.of(0, 2));
-        assertThat(trips.getTotalElements()).isEqualTo(2);
+        assertThat(trips.getTotalElements()).isEqualTo(3);
         assertThat(trips.getPageable().getOffset()).isEqualTo(0);
         assertThat(trips.getPageable().getPageSize()).isEqualTo(2);
         assertThat(trips.getContent().getFirst().hashTags()).contains("test", "Test 해시 코드");
-        assertThat(trips.getContent().getLast().hashTags()).contains("test", "Test 해시 코드");
     }
 
 
@@ -545,7 +552,7 @@ class TripServiceTest extends BaseTripServiceTest {
     @DisplayName("최대 참여 인원을 현재 참여 인원보다 적게 변경할 수 없다.")
     void cannot_update_maxParticipants_lessThan_currentParticipants() {
         // given
-        Trip trip = TripFixture.createTestTrip(memberId, "인원 축소 테스트", "설명", TripCategory.DOMESTIC, TripStatus.RECRUITING);
+        Trip trip = TripFixture.createTestTrip(memberId, "인원 축소 테스트", "설명", TripCategory.DOMESTIC);
         trip.addParticipant(TripParticipant.createTripParticipant(UUID.randomUUID(), trip));
         trip.addParticipant(TripParticipant.createTripParticipant(UUID.randomUUID(), trip));
         tripRepository.save(trip);
@@ -561,7 +568,7 @@ class TripServiceTest extends BaseTripServiceTest {
     void isLeader_check_works_correctly() {
         // given
         UUID nonLeaderId = UUID.randomUUID();
-        Trip trip = TripFixture.createTestTrip(memberId, "isLeader 테스트", "설명", TripCategory.DOMESTIC, TripStatus.RECRUITING);
+        Trip trip = TripFixture.createTestTrip(memberId, "isLeader 테스트", "설명", TripCategory.DOMESTIC);
         trip.addParticipant(TripParticipant.createTripParticipant(nonLeaderId, trip));
         tripRepository.save(trip);
 
@@ -667,6 +674,7 @@ class TripServiceTest extends BaseTripServiceTest {
                     TripStatus.RECRUITING,
                     TripStatus.RECRUITING.getViewName(),
                     "",
+                    TEST_IMAGE_URL,
                     "여행 설명",
                     List.of("test", "Test 해시 코드"),
                     List.of(

--- a/src/test/java/com/retrip/trip/application/in/service/DemandServiceTest.java
+++ b/src/test/java/com/retrip/trip/application/in/service/DemandServiceTest.java
@@ -35,7 +35,7 @@ class DemandServiceTest extends BaseDemandServiceTest {
     }
 
     private Trip createTestTrip(String title, String description, TripCategory category) {
-        Trip trip = TripFixture.createTestTrip(LEADER_ID, title, description, category, TripStatus.RECRUITING);
+        Trip trip = TripFixture.createTestTrip(LEADER_ID, title, description, category);
         return tripRepository.save(trip);
     }
 

--- a/src/test/java/com/retrip/trip/domain/entity/TripTest.java
+++ b/src/test/java/com/retrip/trip/domain/entity/TripTest.java
@@ -32,6 +32,7 @@ class TripTest {
                 memberId,
                 destinationId,
                 new TripTitle("속초 여행 멤버 구함"),
+                "https://image.url",
                 new TripDescription("속초 여행은 이렇게이렇게 갈겁니다~"),
                 new TripPeriod(
                         LocalDate.now().plusDays(1),
@@ -50,6 +51,7 @@ class TripTest {
                 memberId,
                 destinationId,
                 new TripTitle("속초 여행 멤버 구함"),
+                "https://image.url",
                 new TripDescription("속초 여행은 이렇게이렇게 갈겁니다~"),
                 new TripPeriod(
                         LocalDate.now().plusDays(1),
@@ -57,7 +59,8 @@ class TripTest {
                 true,
                 4,
                 List.of("속초 여행"),
-                TripCategory.DOMESTIC
+                TripCategory.DOMESTIC,
+                TripStatus.RECRUITING
         )).doesNotThrowAnyException();
     }
 
@@ -68,6 +71,7 @@ class TripTest {
                 memberId,
                 destinationId,
                 new TripTitle("속초 여행 멤버 구함"),
+                "https://image.url",
                 new TripDescription("속초 여행은 이렇게이렇게 갈겁니다~"),
                 new TripPeriod(
                         LocalDate.now().plusDays(1),
@@ -96,6 +100,7 @@ class TripTest {
                 memberId,
                 UUID.randomUUID(),
                 new TripTitle("속초 여행 멤버 구함"),
+                "https://image.url",
                 new TripDescription("속초 여행은 이렇게이렇게 갈겁니다~"),
                 period,
                 true,
@@ -122,6 +127,7 @@ class TripTest {
                 UUID.randomUUID(),
                 UUID.randomUUID(),
                 new TripTitle("속초 여행 멤버 구함"),
+                "https://image.url",
                 new TripDescription("속초 여행은 이렇게이렇게 갈겁니다~"),
                 period,
                 true,

--- a/src/test/java/com/retrip/trip/domain/fixture/TripFixture.java
+++ b/src/test/java/com/retrip/trip/domain/fixture/TripFixture.java
@@ -3,12 +3,10 @@ package com.retrip.trip.domain.fixture;
 import com.retrip.trip.domain.entity.Trip;
 import com.retrip.trip.domain.entity.TripParticipant;
 import com.retrip.trip.domain.vo.*;
-
-import java.util.List;
-
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 
 public class TripFixture {
@@ -21,34 +19,39 @@ public class TripFixture {
     public static final UUID 지수_ID = UUID.fromString("de3b60d2-5672-464d-8769-bf5c9de5eaff");
     public static final UUID 혁진_ID = UUID.fromString("42880aaf-4b97-4b0c-8a8a-72df4bb592f6");
 
+    private static final String TEST_IMAGE_URL = "https://test-image.com/default.jpg";
+
     public static Trip createTrip(UUID tripId) {
         Trip trip = Trip.createWithItineraries(
                 LEADER_ID,
                 UUID.randomUUID(),
                 new TripTitle("속초 여행 멤버 구함"),
+                TEST_IMAGE_URL,
                 new TripDescription("속초 여행은 이렇게이렇게 갈겁니다~"),
                 new TripPeriod(LocalDate.now().plusDays(1), LocalDate.now().plusDays(10)),
                 true,
                 4,
                 List.of("test", "Test 해시 코드"),
-                TripCategory.DOMESTIC);
+                TripCategory.DOMESTIC,
+                TripStatus.RECRUITING);
         ReflectionTestUtils.setField(trip, "id", tripId);
         return trip;
     }
 
-    public static Trip createTestTrip(UUID memberId, String title, String description, TripCategory category, TripStatus status) {
+    public static Trip createTestTrip(UUID memberId, String title, String description, TripCategory category) {
         TripPeriod period = createFuturePeriod();
         return Trip.create(
                 memberId,
                 UUID.randomUUID(),
                 new TripTitle(title),
+                TEST_IMAGE_URL,
                 new TripDescription(description),
                 period,
                 true,
                 4,
                 List.of("test", "Test 해시 코드"),
                 category,
-                status);
+                TripStatus.RECRUITING);
     }
 
     public static Trip createTestTripWithPeriod(UUID memberId, String title, String description, TripCategory category, TripPeriod period) {
@@ -56,12 +59,14 @@ public class TripFixture {
                 memberId,
                 UUID.randomUUID(),
                 new TripTitle(title),
+                TEST_IMAGE_URL,
                 new TripDescription(description),
                 period,
                 true,
                 4,
                 List.of("test", "Test 해시 코드"),
-                category);
+                category,
+                TripStatus.RECRUITING);
     }
 
     public static Trip createTestTripWithMaxParticipants(UUID memberId, String title, String description, TripCategory category, int maxParticipants) {
@@ -70,12 +75,14 @@ public class TripFixture {
                 memberId,
                 UUID.randomUUID(),
                 new TripTitle(title),
+                TEST_IMAGE_URL,
                 new TripDescription(description),
                 period,
                 true,
                 maxParticipants,
                 List.of("test", "Test 해시 코드"),
-                category, TripStatus.RECRUITING);
+                category,
+                TripStatus.RECRUITING);
     }
 
     public static Trip createReadyTrip(UUID memberId, String title, String description, TripCategory category) {
@@ -84,16 +91,17 @@ public class TripFixture {
                 memberId,
                 UUID.randomUUID(),
                 new TripTitle(title),
+                TEST_IMAGE_URL,
                 new TripDescription(description),
                 period,
                 true,
                 4,
                 List.of("test", "Test 해시 코드"),
-                category, TripStatus.RECRUITING);
+                category,
+                TripStatus.RECRUITING);
         ReflectionTestUtils.setField(trip, "status", TripStatus.BEFORE_TRIP);
         return trip;
     }
-
 
     public static Trip createProgressTrip(UUID memberId, String title, String description, TripCategory category) {
         TripPeriod period = createFuturePeriod();
@@ -101,12 +109,14 @@ public class TripFixture {
                 memberId,
                 UUID.randomUUID(),
                 new TripTitle(title),
+                TEST_IMAGE_URL,
                 new TripDescription(description),
                 period,
                 true,
                 4,
                 List.of("test", "Test 해시 코드"),
-                category, TripStatus.RECRUITING);
+                category,
+                TripStatus.RECRUITING);
         ReflectionTestUtils.setField(trip, "status", TripStatus.IN_PROGRESS);
         return trip;
     }
@@ -116,7 +126,7 @@ public class TripFixture {
     }
 
     public static Trip createTestTripWithParticipants() {
-        Trip trip = createTestTrip(LEADER_ID, "테스트 여행", "여행 설명", TripCategory.DOMESTIC, TripStatus.RECRUITING);
+        Trip trip = createTestTrip(LEADER_ID, "테스트 여행", "여행 설명", TripCategory.DOMESTIC);
         trip.addParticipant(TripParticipant.createTripParticipant(정수_ID, trip));
         trip.addParticipant(TripParticipant.createTripParticipant(홍석_ID, trip));
         trip.addParticipant(TripParticipant.createTripParticipant(준호_ID, trip));


### PR DESCRIPTION
## 🔍 PR 타입 선택

아래 타입 중 해당하는 하나를 선택해 주세요. 반드시 하나만 선택해 주세요.

- [x] `feat`: 새로운 기능 추가
- [ ] `fix`: 버그 수정
- [ ] `docs`: 문서 수정
- [ ] `style`: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] `refactor`: 코드 리팩토링
- [x] `test`: 테스트 코드 추가 또는 수정
- [ ] `chore`: 빌드 업무 수정, 패키지 매니저 수정 등 기타 작업


## 📝 변경 사항 요약

여행 목록/상세 조회 및 생성 시 피그마 UI 스펙에 맞춰 누락된 데이터(대표 이미지, 인원수 정보, 상태 값)를 추가하고, 관련 DTO와 로직을 보완했습니다.

- **여행 도메인**: `Trip` 엔티티 및 관련 DTO에 `imageUrl` 필드 추가
- **목록 조회 API**: `TripResponse`에 현재/최대 인원수, 여행 상태, 이미지 URL 필드 추가
- **생성 API 개선**: `TripCreateRequest`에서 여행 생성 시 기본 상태(`RECRUITING`)가 적용되도록 수정
- **테스트 보완**: 변경된 스펙(이미지 URL 등)에 맞춰 `TripFixture` 및 테스트 코드 업데이트


## 🛠 관련 이슈

Resolves: # (관련 이슈 번호가 있다면 입력해주세요)
# Ref: #

### **추가 설명 (선택 사항)**

#### 1. 피그마 스펙 반영 (데이터 누락 해결)
- **`TripResponse` (목록 조회)**: 프론트엔드 카드 UI 구현을 위해 `imageUrl`, `status`, `currentParticipantCount`, `maxParticipantCount`, `destinationName` 필드를 추가했습니다.
- **`TripDetailResponse` (상세 조회)**: 상세 페이지 헤더에 이미지를 표시할 수 있도록 `imageUrl`을 추가했습니다.
- **`TripCreateRequest` (생성 요청)**: 사용자가 이미지를 업로드하고 URL을 전달할 수 있도록 `imageUrl` 필드를 추가했습니다.

#### 2. 로직 및 구조 개선
- **`Trip` 엔티티**: `imageUrl` 컬럼을 추가하고, 생성 메서드(`create`) 시그니처에 해당 파라미터를 추가했습니다.
- **상태 값 처리**: `TripCreateRequest`를 통해 여행을 생성할 때, `TripStatus.RECRUITING`(모집 중) 상태가 자동으로 주입되도록 구현했습니다.
    - *참고: 기존 테스트 코드들의 수정 범위를 최소화하기 위해, `Trip` 엔티티의 `create` 메서드는 `status`를 인자로 받는 구조를 유지했습니다.*

#### 3. 테스트 코드 수정
- `TripFixture`에 테스트용 이미지 URL 상수를 추가하고, `create` 메서드 시그니처 변경에 따라 팩토리 메서드들을 수정했습니다.
- `TripServiceTest`와 `TripTest` 등에서 여행 생성 시 이미지 URL을 포함하도록 검증 로직을 업데이트했습니다.