### PR TITLE
fix: 여행 목록 조회 시 전체 페이지 수 오류 수정

### DIFF
--- a/src/main/java/com/retrip/trip/application/in/TripService.java
+++ b/src/main/java/com/retrip/trip/application/in/TripService.java
@@ -64,9 +64,11 @@ public class TripService
     @Transactional(readOnly = true)
     @Override
     public Page<TripResponse> getTrips(Pageable page) {
-        List<Trip> trips = tripQueryRepository.findTrips(page);
+        Page<Trip> tripsPage = tripQueryRepository.findTrips(page);
+        List<Trip> trips = tripsPage.getContent();
         List<TripHashTag> hashTags = tripQueryRepository.findHashTags(trips);
-        return new PageImpl<>(TripResponse.of(trips, hashTags), page, trips.size());
+        
+        return new PageImpl<>(TripResponse.of(trips, hashTags), page, tripsPage.getTotalElements());
     }
 
     @Override

--- a/src/main/java/com/retrip/trip/application/out/repository/TripQueryRepository.java
+++ b/src/main/java/com/retrip/trip/application/out/repository/TripQueryRepository.java
@@ -2,20 +2,17 @@ package com.retrip.trip.application.out.repository;
 
 import com.retrip.trip.application.in.response.MyTripResponse;
 import com.retrip.trip.domain.entity.Trip;
-
 import com.retrip.trip.domain.entity.TripHashTag;
-
 import com.retrip.trip.domain.vo.TripStatus;
-import java.util.List;
-import java.util.Optional;
-
-import java.util.UUID;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
 public interface TripQueryRepository {
-    List<Trip> findTrips(Pageable page);
+    Page<Trip> findTrips(Pageable page);
 
     Page<MyTripResponse> findMyTrips(UUID memberId, TripStatus tripStatus, Pageable page);
 

--- a/src/main/java/com/retrip/trip/infra/adapter/out/persistence/mysql/query/TripQuerydslRepository.java
+++ b/src/main/java/com/retrip/trip/infra/adapter/out/persistence/mysql/query/TripQuerydslRepository.java
@@ -3,10 +3,10 @@ package com.retrip.trip.infra.adapter.out.persistence.mysql.query;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.retrip.trip.application.in.response.MyTripResponse;
 import com.retrip.trip.application.out.repository.TripQueryRepository;
-import com.retrip.trip.domain.entity.QTrip;
 import com.retrip.trip.domain.entity.QTripParticipant;
 import com.retrip.trip.domain.entity.Trip;
 import com.retrip.trip.domain.entity.TripHashTag;
@@ -14,6 +14,7 @@ import com.retrip.trip.domain.vo.TripStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -33,13 +34,19 @@ public class TripQuerydslRepository implements TripQueryRepository {
     private final JPAQueryFactory query;
 
     @Override
-    public List<Trip> findTrips(Pageable page) {
-        return query
+    public Page<Trip> findTrips(Pageable page) {
+        List<Trip> content = query
                 .selectFrom(trip)
                 .offset(page.getOffset())
                 .limit(page.getPageSize())
                 .orderBy(trip.createdAt.desc())
                 .fetch();
+
+        JPAQuery<Long> countQuery = query
+                .select(trip.count())
+                .from(trip);
+
+        return PageableExecutionUtils.getPage(content, page, countQuery::fetchOne);
     }
 
     @Override

--- a/src/test/java/com/retrip/trip/application/in/TripServiceTest.java
+++ b/src/test/java/com/retrip/trip/application/in/TripServiceTest.java
@@ -81,7 +81,6 @@ class TripServiceTest extends BaseTripServiceTest {
 
     @Test
     void 여행_목록을_조회한다() {
-        // TripFixture 호출 시 status 파라미터 관련 문제 해결을 위해 createTestTrip 헬퍼 메서드 사용 (위에서 수정함)
         tripRepository.save(createTestTrip("속초 여행 맴버 구함", "속초 여행은 이렇게이렇게 갈겁니다~", TripCategory.DOMESTIC, TripStatus.RECRUITING));
         tripRepository.save(createTestTrip("대구 여행 멤버 구함", "대구 여행은 이렇게이렇게 갈겁니다~", TripCategory.DOMESTIC, TripStatus.RECRUITING));
         tripRepository.save(createTestTrip("부산 여행 멤버 구함", "부산 여행은 이렇게이렇게 갈겁니다~", TripCategory.DOMESTIC, TripStatus.RECRUITING));


### PR DESCRIPTION
## 🔍 PR 타입 선택

아래 타입 중 해당하는 하나를 선택해 주세요. 반드시 하나만 선택해 주세요.

- [ ] `feat`: 새로운 기능 추가
- [ ] `fix`: 버그 수정
- [ ] `docs`: 문서 수정
- [ ] `style`: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] `refactor`: 코드 리팩토링
- [ ] `test`: 테스트 코드 추가 또는 수정
- [ ] `chore`: 빌드 업무 수정, 패키지 매니저 수정 등 기타 작업


## 📝 변경 사항 요약

여행 목록 조회 시 전체 페이지 수 오류 수정

TripQueryRepository에 전체 데이터 개수(count) 조회 로직 추가

TripService에서 PageImpl 생성 시 현재 페이지 크기가 아닌 전체 개수를 전달하도록 수정

프론트엔드 페이징 처리(totalElements, totalPages, last) 정상화


## 🛠 관련 이슈

Resolves: #123  
Ref: #456  
Related to: #48, #45
close: #번호

### **추가 설명 (선택 사항)**

변경 사항에 대한 추가 설명을 작성해 주세요.
