### PR TITLE
feat: 여행리더의 여행 일정 조회, 생성, 수정, 삭제 (ver 2) (#67)

### DIFF
--- a/src/main/java/com/retrip/trip/application/in/ItineraryService.java
+++ b/src/main/java/com/retrip/trip/application/in/ItineraryService.java
@@ -1,5 +1,8 @@
 package com.retrip.trip.application.in;
 
+import com.retrip.trip.application.in.request.ItineraryDetailMoveRequest;
+import com.retrip.trip.application.in.request.ItineraryDetailReorderRequest;
+import com.retrip.trip.application.in.request.ItineraryDetailsBulkCreateRequest;
 import com.retrip.trip.application.in.request.ItineraryDetailsCreateRequest;
 import com.retrip.trip.application.in.request.ItineraryDetailsUpdateRequest;
 import com.retrip.trip.application.in.response.ItineraryDetailsCreateResponse;
@@ -10,15 +13,13 @@ import com.retrip.trip.application.in.usecase.ManageItineraryDetailsUseCase;
 import com.retrip.trip.application.out.repository.TripItineraryQueryRepository;
 import com.retrip.trip.domain.entity.Itinerary;
 import com.retrip.trip.domain.entity.ItineraryDetail;
-
-import java.util.UUID;
-
 import com.retrip.trip.domain.exception.common.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
 
 import static com.retrip.trip.domain.exception.common.ErrorCode.ITINERARY_NOT_FOUND;
 
@@ -29,37 +30,85 @@ public class ItineraryService implements ManageItineraryDetailsUseCase, GetItine
     private final TripItineraryQueryRepository tripItineraryQueryRepository;
 
     @Override
-    public ItineraryDetailsCreateResponse createItineraryDetails(UUID tripId, UUID itineraryId,
+    public ItineraryDetailsCreateResponse createItineraryDetails(UUID tripId,
+                                                                 UUID itineraryId,
                                                                  ItineraryDetailsCreateRequest request) {
-        Itinerary itinerary = tripItineraryQueryRepository.findByIdWithItineraryDetails(itineraryId)
-                .orElseThrow(() -> new EntityNotFoundException(ITINERARY_NOT_FOUND));
-        ItineraryDetail itineraryDetail = request.to(itinerary);
+        Itinerary itinerary = findItineraryWithDetails(itineraryId);
+        int sortOrder = itinerary.getItineraryDetails() != null ? itinerary.getItineraryDetails().nextSortOrder() : 0;
+        ItineraryDetail itineraryDetail = request.to(itinerary, sortOrder);
         itinerary.addItineraryDetail(itineraryDetail);
         return ItineraryDetailsCreateResponse.of(itineraryDetail);
     }
 
     @Override
-    public ItineraryDetailsUpdateResponse updateItineraryDetails(
-            UUID tripId,
-            UUID itineraryId,
-            UUID itineraryDetailId,
-            ItineraryDetailsUpdateRequest request) {
-        Itinerary itinerary = tripItineraryQueryRepository.findByIdWithItineraryDetails(itineraryId)
-                .orElseThrow(() -> new EntityNotFoundException(ITINERARY_NOT_FOUND));
-        ItineraryDetail itineraryDetail = request.to(itinerary);
-        itinerary.updateItineraryDetail(itineraryDetail, itineraryDetailId);
-        return ItineraryDetailsUpdateResponse.of(itineraryDetail);
+    public List<ItineraryDetailsCreateResponse> bulkCreateItineraryDetails(UUID tripId,
+                                                                           UUID itineraryId,
+                                                                           ItineraryDetailsBulkCreateRequest request) {
+        Itinerary itinerary = findItineraryWithDetails(itineraryId);
+        List<ItineraryDetail> details = request.items().stream()
+                .map(item -> item.to(itinerary))
+                .toList();
+        return itinerary.addItineraryDetails(details).stream()
+                .map(ItineraryDetailsCreateResponse::of)
+                .toList();
     }
 
     @Override
-    public void deleteItineraryDetail(UUID tripId, UUID itineraryId, UUID itineraryDetailsId) {
+    public void deleteAllItineraryDetails(UUID tripId, UUID itineraryId) {
+        Itinerary itinerary = findItineraryWithDetails(itineraryId);
+        itinerary.removeAllItineraries();
+    }
+
+    @Override
+    public ItineraryDetailsUpdateResponse updateItineraryDetails(UUID tripId, UUID itineraryId,
+                                                                 UUID itineraryDetailId,
+                                                                 ItineraryDetailsUpdateRequest request) {
+        Itinerary itinerary = findItineraryWithDetails(itineraryId);
+        itinerary.updateItineraryDetail(itineraryDetailId, request.memo(), request.time(), request.locationId());
+        ItineraryDetail updated = itinerary.getItineraryDetails().getValues().stream()
+                .filter(detail -> detail.getId().equals(itineraryDetailId))
+                .findFirst()
+                .orElseThrow(() -> new EntityNotFoundException(ITINERARY_NOT_FOUND));
+        return ItineraryDetailsUpdateResponse.of(updated);
+    }
+
+    @Override
+    public void deleteItineraryDetail(UUID tripId,
+                                      UUID itineraryId,
+                                      UUID itineraryDetailsId) {
         Itinerary itinerary = tripItineraryQueryRepository.findByIdWithItineraryDetail(itineraryId, itineraryDetailsId)
                 .orElseThrow(() -> new EntityNotFoundException(ITINERARY_NOT_FOUND));
         itinerary.removeItineraryDetail(itineraryDetailsId);
     }
 
     @Override
-    public Page<ItineraryResponse> getItineraries(UUID tripId, Pageable page) {
-        return tripItineraryQueryRepository.findItineraries(tripId, page);
+    public void moveItineraryDetail(UUID tripId,
+                                    UUID itineraryId,
+                                    UUID itineraryDetailId,
+                                    ItineraryDetailMoveRequest request) {
+        Itinerary source = findItineraryWithDetails(itineraryId);
+        Itinerary target = findItineraryWithDetails(request.targetItineraryId());
+
+        ItineraryDetail detail = source.removeDetailForMove(itineraryDetailId);
+        target.acceptMovedDetail(detail, request.targetSortOrder());
+    }
+
+    @Override
+    public void reorderItineraryDetails(UUID tripId,
+                                        UUID itineraryId,
+                                        ItineraryDetailReorderRequest request) {
+        Itinerary itinerary = findItineraryWithDetails(itineraryId);
+        itinerary.reorderItineraryDetails(request.orderedIds());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ItineraryResponse> getItineraries(UUID tripId) {
+        return tripItineraryQueryRepository.findItineraries(tripId);
+    }
+
+    private Itinerary findItineraryWithDetails(UUID itineraryId) {
+        return tripItineraryQueryRepository.findByIdWithItineraryDetails(itineraryId)
+                .orElseThrow(() -> new EntityNotFoundException(ITINERARY_NOT_FOUND));
     }
 }

--- a/src/main/java/com/retrip/trip/application/in/request/ItineraryDetailsCreateRequest.java
+++ b/src/main/java/com/retrip/trip/application/in/request/ItineraryDetailsCreateRequest.java
@@ -3,25 +3,17 @@ package com.retrip.trip.application.in.request;
 import com.retrip.trip.domain.entity.Itinerary;
 import com.retrip.trip.domain.entity.ItineraryDetail;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 
-import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Schema(description = "여행 일정 세부사항 생성 Request")
 public record ItineraryDetailsCreateRequest(
-        @Schema(description = "일정 시간")
-        LocalDateTime time,
-
-        @Schema(description = "일정 설명")
-        String description,
-
-        @Schema(description = "예상 비용")
-        Long price,
-
+        @NotNull
         @Schema(description = "위치 ID")
         UUID locationId
 ) {
-    public ItineraryDetail to(Itinerary itinerary) {
-        return ItineraryDetail.create(price, description, time, itinerary, locationId);
+    public ItineraryDetail to(Itinerary itinerary, int sortOrder) {
+        return ItineraryDetail.create(null, null, itinerary, locationId, sortOrder);
     }
 }

--- a/src/main/java/com/retrip/trip/application/in/request/ItineraryDetailsUpdateRequest.java
+++ b/src/main/java/com/retrip/trip/application/in/request/ItineraryDetailsUpdateRequest.java
@@ -1,7 +1,5 @@
 package com.retrip.trip.application.in.request;
 
-import com.retrip.trip.domain.entity.Itinerary;
-import com.retrip.trip.domain.entity.ItineraryDetail;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
@@ -9,19 +7,12 @@ import java.util.UUID;
 
 @Schema(description = "여행 일정 세부사항 수정 Request")
 public record ItineraryDetailsUpdateRequest(
-        @Schema(description = "일정 시간")
+        @Schema(description = "일정 시간 (선택)")
         LocalDateTime time,
 
-        @Schema(description = "일정 설명")
-        String description,
+        @Schema(description = "메모 (선택, 최대 200자)")
+        String memo,
 
-        @Schema(description = "예상 비용")
-        Long price,
-
-        @Schema(description = "위치 ID")
+        @Schema(description = "위치 ID (선택)")
         UUID locationId
-) {
-    public ItineraryDetail to(Itinerary itinerary) {
-        return ItineraryDetail.create(price, description, time, itinerary, locationId);
-    }
-}
+) {}

--- a/src/main/java/com/retrip/trip/application/in/response/ItineraryDetailsCreateResponse.java
+++ b/src/main/java/com/retrip/trip/application/in/response/ItineraryDetailsCreateResponse.java
@@ -11,25 +11,30 @@ public record ItineraryDetailsCreateResponse(
         @Schema(description = "일정 세부사항 ID")
         UUID id,
 
+        @Schema(description = "위치 ID")
+        UUID locationId,
+
         @Schema(description = "일정 시간")
         LocalDateTime time,
 
-        @Schema(description = "일정 설명")
-        String description,
+        @Schema(description = "메모")
+        String memo,
 
-        @Schema(description = "예상 비용")
-        Long price,
+        @Schema(description = "정렬 순서")
+        int sortOrder,
 
-        @Schema(description = "위치 ID")
-        UUID locationId
+        @Schema(description = "장소명 (TODO: map service API 연동 후 locationId로 조회)")
+        String locationName
 ) {
-    public static ItineraryDetailsCreateResponse of(ItineraryDetail itineraryDetail) {
+    public static ItineraryDetailsCreateResponse of(ItineraryDetail detail) {
+        // TODO: map service API 호출하여 locationId → locationName 조회
         return new ItineraryDetailsCreateResponse(
-                itineraryDetail.getId(),
-                itineraryDetail.getTime().getValue(),
-                itineraryDetail.getDescription().getValue(),
-                itineraryDetail.getPrice().getValue(),
-                itineraryDetail.getLocationId()
+                detail.getId(),
+                detail.getLocationId(),
+                detail.getTimeValue(),
+                detail.getMemoValue(),
+                detail.getSortOrder(),
+                null
         );
     }
 }

--- a/src/main/java/com/retrip/trip/application/in/response/ItineraryDetailsUpdateResponse.java
+++ b/src/main/java/com/retrip/trip/application/in/response/ItineraryDetailsUpdateResponse.java
@@ -11,25 +11,30 @@ public record ItineraryDetailsUpdateResponse(
         @Schema(description = "일정 세부사항 ID")
         UUID id,
 
+        @Schema(description = "위치 ID")
+        UUID locationId,
+
         @Schema(description = "일정 시간")
         LocalDateTime time,
 
-        @Schema(description = "일정 설명")
-        String description,
+        @Schema(description = "메모")
+        String memo,
 
-        @Schema(description = "예상 비용")
-        Long price,
+        @Schema(description = "정렬 순서")
+        int sortOrder,
 
-        @Schema(description = "위치 ID")
-        UUID locationId
+        @Schema(description = "장소명 (TODO: map service API 연동 후 locationId로 조회)")
+        String locationName
 ) {
-    public static ItineraryDetailsUpdateResponse of(ItineraryDetail itineraryDetail) {
+    public static ItineraryDetailsUpdateResponse of(ItineraryDetail detail) {
+        // TODO: map service API 호출하여 locationId → locationName 조회
         return new ItineraryDetailsUpdateResponse(
-                itineraryDetail.getId(),
-                itineraryDetail.getTime().getValue(),
-                itineraryDetail.getDescription().getValue(),
-                itineraryDetail.getPrice().getValue(),
-                itineraryDetail.getLocationId()
+                detail.getId(),
+                detail.getLocationId(),
+                detail.getTimeValue(),
+                detail.getMemoValue(),
+                detail.getSortOrder(),
+                null
         );
     }
 }

--- a/src/main/java/com/retrip/trip/application/in/response/ItineraryResponse.java
+++ b/src/main/java/com/retrip/trip/application/in/response/ItineraryResponse.java
@@ -18,24 +18,27 @@ public record ItineraryResponse(
         @Schema(description = "일정 이름")
         String name,
 
-        @Schema(description = "일정 세부사항 목록")
-        List<ItineraryDetailResponse> itineraryDetailResponse
+        @Schema(description = "일정 세부사항 목록 (sortOrder 오름차순)")
+        List<ItineraryDetailResponse> itineraryDetails
 ) {
     @Schema(description = "일정 세부사항 Response")
     public record ItineraryDetailResponse(
             @Schema(description = "세부사항 ID")
             UUID id,
 
-            @Schema(description = "세부사항 설명")
-            String description,
+            @Schema(description = "위치 ID")
+            UUID locationId,
+
+            @Schema(description = "장소명 (TODO: map service API 연동 후 locationId로 조회)")
+            String locationName,
 
             @Schema(description = "일정 시간")
             LocalDateTime time,
 
-            @Schema(description = "예상 비용")
-            Long price,
+            @Schema(description = "메모")
+            String memo,
 
-            @Schema(description = "위치 ID")
-            UUID locationId
+            @Schema(description = "정렬 순서")
+            int sortOrder
     ) {}
 }

--- a/src/main/java/com/retrip/trip/application/in/usecase/GetItinerariesUseCase.java
+++ b/src/main/java/com/retrip/trip/application/in/usecase/GetItinerariesUseCase.java
@@ -2,12 +2,9 @@ package com.retrip.trip.application.in.usecase;
 
 import com.retrip.trip.application.in.response.ItineraryResponse;
 
+import java.util.List;
 import java.util.UUID;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-
 public interface GetItinerariesUseCase {
-    Page<ItineraryResponse> getItineraries(UUID tripId, Pageable page);
-
+    List<ItineraryResponse> getItineraries(UUID tripId);
 }

--- a/src/main/java/com/retrip/trip/application/in/usecase/ManageItineraryDetailsUseCase.java
+++ b/src/main/java/com/retrip/trip/application/in/usecase/ManageItineraryDetailsUseCase.java
@@ -1,19 +1,28 @@
 package com.retrip.trip.application.in.usecase;
 
+import com.retrip.trip.application.in.request.ItineraryDetailMoveRequest;
+import com.retrip.trip.application.in.request.ItineraryDetailReorderRequest;
+import com.retrip.trip.application.in.request.ItineraryDetailsBulkCreateRequest;
 import com.retrip.trip.application.in.request.ItineraryDetailsCreateRequest;
 import com.retrip.trip.application.in.request.ItineraryDetailsUpdateRequest;
-
 import com.retrip.trip.application.in.response.ItineraryDetailsCreateResponse;
-
 import com.retrip.trip.application.in.response.ItineraryDetailsUpdateResponse;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface ManageItineraryDetailsUseCase {
     ItineraryDetailsCreateResponse createItineraryDetails(UUID tripId, UUID itineraryId, ItineraryDetailsCreateRequest request);
 
+    List<ItineraryDetailsCreateResponse> bulkCreateItineraryDetails(UUID tripId, UUID itineraryId, ItineraryDetailsBulkCreateRequest request);
+
     ItineraryDetailsUpdateResponse updateItineraryDetails(UUID tripId, UUID itineraryId, UUID itineraryDetailId, ItineraryDetailsUpdateRequest request);
 
     void deleteItineraryDetail(UUID tripId, UUID itineraryId, UUID itineraryDetailsId);
 
+    void deleteAllItineraryDetails(UUID tripId, UUID itineraryId);
+
+    void moveItineraryDetail(UUID tripId, UUID itineraryId, UUID itineraryDetailId, ItineraryDetailMoveRequest request);
+
+    void reorderItineraryDetails(UUID tripId, UUID itineraryId, ItineraryDetailReorderRequest request);
 }

--- a/src/main/java/com/retrip/trip/application/out/repository/TripItineraryQueryRepository.java
+++ b/src/main/java/com/retrip/trip/application/out/repository/TripItineraryQueryRepository.java
@@ -7,9 +7,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-
 public interface TripItineraryQueryRepository {
     List<Itinerary> findByIdsWithItineraryDetails(List<UUID> ids);
 
@@ -17,5 +14,5 @@ public interface TripItineraryQueryRepository {
 
     Optional<Itinerary> findByIdWithItineraryDetails(UUID itineraryId);
 
-    Page<ItineraryResponse> findItineraries(UUID tripId, Pageable page);
+    List<ItineraryResponse> findItineraries(UUID tripId);
 }

--- a/src/main/java/com/retrip/trip/domain/entity/Itinerary.java
+++ b/src/main/java/com/retrip/trip/domain/entity/Itinerary.java
@@ -6,6 +6,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -73,10 +75,34 @@ public class Itinerary extends BaseEntity {
         if (Objects.isNull(this.itineraryDetails)) {
             this.itineraryDetails = new ItineraryDetails();
         }
-        this.getItineraryDetails().addItineraryDetail(itineraryDetail, this.date);
+        this.itineraryDetails.addItineraryDetail(itineraryDetail);
     }
 
-    public void updateItineraryDetail(ItineraryDetail itineraryDetail, UUID updateId) {
-        this.getItineraryDetails().updateItineraryDetail(itineraryDetail, this.date, updateId);
+    public List<ItineraryDetail> addItineraryDetails(List<ItineraryDetail> details) {
+        if (Objects.isNull(this.itineraryDetails)) {
+            this.itineraryDetails = new ItineraryDetails();
+        }
+        this.itineraryDetails.addAll(details);
+        return details;
+    }
+
+    public void updateItineraryDetail(UUID detailId, String memo, LocalDateTime time, UUID locationId) {
+        this.itineraryDetails.updateItineraryDetail(detailId, memo, time, locationId);
+    }
+
+    public void reorderItineraryDetails(List<UUID> orderedIds) {
+        this.itineraryDetails.reorder(orderedIds);
+    }
+
+    public ItineraryDetail removeDetailForMove(UUID detailId) {
+        return this.itineraryDetails.removeForMove(detailId);
+    }
+
+    public void acceptMovedDetail(ItineraryDetail detail, int targetSortOrder) {
+        if (Objects.isNull(this.itineraryDetails)) {
+            this.itineraryDetails = new ItineraryDetails();
+        }
+        detail.moveTo(this, targetSortOrder);
+        this.itineraryDetails.insertAtOrder(detail, targetSortOrder);
     }
 }

--- a/src/main/java/com/retrip/trip/domain/entity/ItineraryDetail.java
+++ b/src/main/java/com/retrip/trip/domain/entity/ItineraryDetail.java
@@ -2,8 +2,7 @@ package com.retrip.trip.domain.entity;
 
 import static lombok.AccessLevel.PROTECTED;
 
-import com.retrip.trip.domain.vo.ItineraryDetailDescription;
-import com.retrip.trip.domain.vo.ItineraryDetailPrice;
+import com.retrip.trip.domain.vo.ItineraryDetailMemo;
 import com.retrip.trip.domain.vo.ItineraryDetailTime;
 import jakarta.persistence.*;
 
@@ -22,11 +21,13 @@ public class ItineraryDetail extends BaseEntity {
     private UUID id;
 
     @Embedded
-    private ItineraryDetailPrice price;
-    @Embedded
-    private ItineraryDetailDescription description;
+    private ItineraryDetailMemo memo;
+
     @Embedded
     private ItineraryDetailTime time;
+
+    private int sortOrder;
+
     private UUID locationId;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -37,25 +38,39 @@ public class ItineraryDetail extends BaseEntity {
             foreignKey = @ForeignKey(name = "fk_itinerary_detail_to_itinerary"))
     private Itinerary itinerary;
 
-    private ItineraryDetail(Long price, String description, LocalDateTime time, Itinerary itinerary, UUID locationId) {
+    private ItineraryDetail(String memo, LocalDateTime time, Itinerary itinerary, UUID locationId, int sortOrder) {
         this.id = UUID.randomUUID();
-        this.price = new ItineraryDetailPrice(price);
-        this.description = new ItineraryDetailDescription(description);
+        this.memo = new ItineraryDetailMemo(memo);
         this.time = new ItineraryDetailTime(time);
         this.locationId = locationId;
         this.itinerary = itinerary;
+        this.sortOrder = sortOrder;
     }
 
-    public static ItineraryDetail create(
-            Long price, String description, LocalDateTime time, Itinerary itinerary, UUID locationId) {
-        return new ItineraryDetail(price, description, time, itinerary, locationId);
+    public static ItineraryDetail create(String memo, LocalDateTime time, Itinerary itinerary, UUID locationId, int sortOrder) {
+        return new ItineraryDetail(memo, time, itinerary, locationId, sortOrder);
     }
 
-    public void update(ItineraryDetail itineraryDetail) {
-        this.price = itineraryDetail.getPrice();
-        this.description = itineraryDetail.getDescription();
-        this.time = itineraryDetail.getTime();
-        this.itinerary = itineraryDetail.getItinerary();
-        this.locationId = itineraryDetail.getLocationId();
+    public void update(String memo, LocalDateTime time, UUID locationId) {
+        if (memo != null) this.memo = new ItineraryDetailMemo(memo);
+        if (time != null) this.time = new ItineraryDetailTime(time);
+        if (locationId != null) this.locationId = locationId;
+    }
+
+    public void moveTo(Itinerary target, int newSortOrder) {
+        this.itinerary = target;
+        this.sortOrder = newSortOrder;
+    }
+
+    public void updateSortOrder(int sortOrder) {
+        this.sortOrder = sortOrder;
+    }
+
+    public String getMemoValue() {
+        return memo != null ? memo.getValue() : null;
+    }
+
+    public LocalDateTime getTimeValue() {
+        return time != null ? time.getValue() : null;
     }
 }

--- a/src/main/java/com/retrip/trip/domain/entity/ItineraryDetails.java
+++ b/src/main/java/com/retrip/trip/domain/entity/ItineraryDetails.java
@@ -1,8 +1,6 @@
 package com.retrip.trip.domain.entity;
 
 import com.retrip.trip.domain.exception.common.EntityNotFoundException;
-import com.retrip.trip.domain.exception.common.InvalidValueException;
-import com.retrip.trip.domain.vo.ItineraryDetailTime;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.OneToMany;
@@ -10,13 +8,13 @@ import jakarta.persistence.OneToMany;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.IntStream;
 
-import static com.retrip.trip.domain.exception.common.ErrorCode.ITINERARY_DATE_MISMATCH;
-import static com.retrip.trip.domain.exception.common.ErrorCode.ITINERARY_TIME_DUPLICATED;
+import static java.util.Comparator.comparingInt;
 import static lombok.AccessLevel.PROTECTED;
 
 @Getter
@@ -32,33 +30,67 @@ public class ItineraryDetails {
 
     public void remove(UUID itineraryDetailsId) {
         this.values.removeIf(it -> it.getId().equals(itineraryDetailsId));
+        reorderAll();
     }
 
-    public void addItineraryDetail(ItineraryDetail itineraryDetail, LocalDate baseDay) {
-        validate(itineraryDetail.getTime(), baseDay);
+    public void addItineraryDetail(ItineraryDetail itineraryDetail) {
         values.add(itineraryDetail);
     }
 
-    public void updateItineraryDetail(ItineraryDetail itineraryDetail, LocalDate baseDay, UUID updateId) {
-        ItineraryDetail updatedItineraryDetail = findByItineraryDetail(updateId);
-        updatedItineraryDetail.update(itineraryDetail);
-        this.values.remove(updatedItineraryDetail);
-
-        validate(itineraryDetail.getTime(), baseDay);
-        values.add(updatedItineraryDetail);
+    public void addAll(List<ItineraryDetail> details) {
+        int baseOrder = values.size();
+        IntStream.range(0, details.size())
+                .forEach(i -> {
+                    details.get(i).updateSortOrder(baseOrder + i);
+                    values.add(details.get(i));
+                });
     }
 
-    private ItineraryDetail findByItineraryDetail(UUID updateId) {
-        return this.values.stream().filter(id -> id.getId().equals(updateId)).findFirst().orElseThrow(EntityNotFoundException::new);
+    public void updateItineraryDetail(UUID detailId, String memo, LocalDateTime time, UUID locationId) {
+        findByItineraryDetail(detailId)
+                .update(memo, time, locationId);
     }
 
-    private void validate(ItineraryDetailTime time, LocalDate baseDay) {
-        if (!baseDay.equals(time.getValue().toLocalDate())) {
-            throw new InvalidValueException(ITINERARY_DATE_MISMATCH);
+    public ItineraryDetail removeForMove(UUID detailId) {
+        ItineraryDetail detail = findByItineraryDetail(detailId);
+        this.values.remove(detail);
+        reorderAll();
+        return detail;
+    }
+
+    public int nextSortOrder() {
+        return values.size();
+    }
+
+    public void insertAtOrder(ItineraryDetail detail, int targetSortOrder) {
+        int insertAt = Math.min(targetSortOrder, values.size());
+        // insertAt 이상인 기존 항목들을 한 칸씩 뒤로 밀기
+        values.stream()
+                .filter(d -> d.getSortOrder() >= insertAt)
+                .forEach(d -> d.updateSortOrder(d.getSortOrder() + 1));
+        detail.updateSortOrder(insertAt);
+        values.add(detail);
+    }
+
+    public void reorder(List<UUID> orderedIds) {
+        for (int i = 0; i < orderedIds.size(); i++) {
+            findByItineraryDetail(orderedIds.get(i)).updateSortOrder(i);
         }
-        if (this.values.stream().anyMatch(id -> id.getTime().equals(time))) {
-            throw new InvalidValueException(ITINERARY_TIME_DUPLICATED);
+    }
+
+    private void reorderAll() {
+        List<ItineraryDetail> sorted = values.stream()
+                .sorted(comparingInt(ItineraryDetail::getSortOrder))
+                .toList();
+        for (int i = 0; i < sorted.size(); i++) {
+            sorted.get(i).updateSortOrder(i);
         }
     }
 
+    private ItineraryDetail findByItineraryDetail(UUID detailId) {
+        return this.values.stream()
+                .filter(detail -> detail.getId().equals(detailId))
+                .findFirst()
+                .orElseThrow(EntityNotFoundException::new);
+    }
 }

--- a/src/main/java/com/retrip/trip/domain/vo/ItineraryDetailMemo.java
+++ b/src/main/java/com/retrip/trip/domain/vo/ItineraryDetailMemo.java
@@ -11,14 +11,14 @@ import lombok.NoArgsConstructor;
 @Embeddable
 @EqualsAndHashCode
 @NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
-public class ItineraryDetailDescription {
+public class ItineraryDetailMemo {
 
-  private static final int MAX_SIZE = 100;
+  private static final int MAX_SIZE = 200;
 
-  @Column(name = "description", length = MAX_SIZE)
+  @Column(name = "memo", length = MAX_SIZE)
   private String value;
 
-  public ItineraryDetailDescription(String value) {
+  public ItineraryDetailMemo(String value) {
     validate(value);
     this.value = value;
   }

--- a/src/main/java/com/retrip/trip/domain/vo/ItineraryDetailTime.java
+++ b/src/main/java/com/retrip/trip/domain/vo/ItineraryDetailTime.java
@@ -4,47 +4,42 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 
 import java.time.temporal.ChronoUnit;
-import java.util.Objects;
 
 import lombok.AccessLevel;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
+@Getter
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
 public class ItineraryDetailTime {
 
-    @Column(name = "time", nullable = false)
+    @Column(name = "time")
     private LocalDateTime value;
 
     public ItineraryDetailTime(LocalDateTime time) {
-        LocalDateTime value = time.truncatedTo(ChronoUnit.HOURS);
-        validate(value);
-        this.value = value;
+        this.value = time != null ? time.truncatedTo(ChronoUnit.HOURS) : null;
     }
 
-    private void validate(LocalDateTime value) {
-        if (value == null) {
-            throw new IllegalArgumentException("여행 상세 시간은 필수입니다.");
-        }
+    public LocalDateTime getValue() {
+        return value != null ? value.truncatedTo(ChronoUnit.HOURS) : null;
     }
 
     @Override
     public boolean equals(Object o) {
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+        if (o == null || getClass() != o.getClass()) return false;
         ItineraryDetailTime that = (ItineraryDetailTime) o;
-        return value.getYear() == that.getValue().getYear()
-                && value.getMonthValue() == that.getValue().getMonthValue()
-                && value.getDayOfMonth() == that.getValue().getDayOfMonth()
-                && value.getHour() == that.getValue().getHour();
+        if (this.value == null || that.value == null) return false;
+        return value.getYear() == that.value.getYear()
+                && value.getMonthValue() == that.value.getMonthValue()
+                && value.getDayOfMonth() == that.value.getDayOfMonth()
+                && value.getHour() == that.value.getHour();
     }
 
-    public LocalDateTime getValue() {
-        return value.truncatedTo(ChronoUnit.HOURS);
+    @Override
+    public int hashCode() {
+        return value == null ? 0 : getValue().hashCode();
     }
 }

--- a/src/main/java/com/retrip/trip/infra/adapter/in/presentation/rest/ItineraryController.java
+++ b/src/main/java/com/retrip/trip/infra/adapter/in/presentation/rest/ItineraryController.java
@@ -1,7 +1,10 @@
 package com.retrip.trip.infra.adapter.in.presentation.rest;
 
-import com.retrip.trip.application.in.request.ItineraryDetailsUpdateRequest;
+import com.retrip.trip.application.in.request.ItineraryDetailMoveRequest;
+import com.retrip.trip.application.in.request.ItineraryDetailReorderRequest;
+import com.retrip.trip.application.in.request.ItineraryDetailsBulkCreateRequest;
 import com.retrip.trip.application.in.request.ItineraryDetailsCreateRequest;
+import com.retrip.trip.application.in.request.ItineraryDetailsUpdateRequest;
 import com.retrip.trip.application.in.response.ItineraryDetailsCreateResponse;
 import com.retrip.trip.application.in.response.ItineraryDetailsUpdateResponse;
 import com.retrip.trip.application.in.response.ItineraryResponse;
@@ -11,14 +14,13 @@ import com.retrip.trip.domain.exception.annotation.ApiErrorCodeExample;
 import com.retrip.trip.domain.exception.annotation.ApiErrorCodeExamples;
 import com.retrip.trip.infra.adapter.in.presentation.rest.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
+import jakarta.validation.Valid;
+
+import java.util.List;
 import java.util.UUID;
 
 import static com.retrip.trip.domain.exception.common.ErrorCode.*;
@@ -31,41 +33,54 @@ public class ItineraryController {
     private final ManageItineraryDetailsUseCase manageItineraryDetailsUseCase;
     private final GetItinerariesUseCase getItinerariesUseCase;
 
-    @Operation(
-            summary = "여행 일정 세부사항 생성",
-            description = "여행 일정 세부사항 생성하는 API"
-    )
-    @ApiErrorCodeExamples({INVITATION_NOT_FOUND, INVALID_INPUT_VALUE, ITINERARY_DATE_MISMATCH, ITINERARY_TIME_DUPLICATED})
+    @Operation(summary = "여행 일정 목록 조회", description = "날짜 오름차순, 세부일정은 sortOrder 오름차순 정렬")
+    @GetMapping("/{tripId}/itineraries")
+    public ApiResponse<List<ItineraryResponse>> getItineraries(@PathVariable UUID tripId) {
+        return ApiResponse.ok(getItinerariesUseCase.getItineraries(tripId));
+    }
+
+    @Operation(summary = "세부일정 추가", description = "장소(locationId)만 필수. 시간/메모는 이후 수정 API로 추가")
+    @ApiErrorCodeExamples({INVITATION_NOT_FOUND, INVALID_INPUT_VALUE, ITINERARY_NOT_FOUND})
     @PostMapping("/{tripId}/itineraries/{itineraryId}/itineraryDetails")
     public ApiResponse<ItineraryDetailsCreateResponse> createItineraryDetails(
             @PathVariable UUID tripId,
             @PathVariable UUID itineraryId,
             @RequestBody ItineraryDetailsCreateRequest request) {
-        ItineraryDetailsCreateResponse itineraryDetail =
-                manageItineraryDetailsUseCase.createItineraryDetails(tripId, itineraryId, request);
-        return ApiResponse.created(itineraryDetail);
+        return ApiResponse.created(manageItineraryDetailsUseCase.createItineraryDetails(tripId, itineraryId, request));
     }
 
-    @Operation(
-            summary = "여행 일정 세부사항 수정",
-            description = "여행 일정 세부사항 수정하는 API"
-    )
-    @ApiErrorCodeExamples({INVITATION_NOT_FOUND, INVALID_INPUT_VALUE, ENTITY_NOT_FOUND, ITINERARY_DATE_MISMATCH, ITINERARY_TIME_DUPLICATED})
+    @Operation(summary = "세부일정 수정", description = "time/memo/locationId 모두 선택 사항 (null 전송 시 해당 필드 미변경)")
+    @ApiErrorCodeExamples({INVITATION_NOT_FOUND, INVALID_INPUT_VALUE, ENTITY_NOT_FOUND, ITINERARY_NOT_FOUND})
     @PutMapping("/{tripId}/itineraries/{itineraryId}/itineraryDetails/{itineraryDetailId}")
     public ApiResponse<ItineraryDetailsUpdateResponse> updateItineraryDetails(
             @PathVariable UUID tripId,
             @PathVariable UUID itineraryId,
             @PathVariable UUID itineraryDetailId,
             @RequestBody ItineraryDetailsUpdateRequest request) {
-        ItineraryDetailsUpdateResponse itineraryDetail =
-                manageItineraryDetailsUseCase.updateItineraryDetails(tripId, itineraryId, itineraryDetailId, request);
-        return ApiResponse.ok(itineraryDetail);
+        return ApiResponse.ok(manageItineraryDetailsUseCase.updateItineraryDetails(tripId, itineraryId, itineraryDetailId, request));
     }
 
-    @Operation(
-            summary = "여행 일정 세부사항 삭제",
-            description = "여행 일정 세부사항 삭제하는 API"
-    )
+    @Operation(summary = "세부일정 일괄 생성", description = "삭제된 하루 일정 복구(실행취소)용. items 순서대로 sortOrder 부여 (프론트가 삭제 전 데이터를 메모리에 보관한 걸 보내면 됨)")
+    @ApiErrorCodeExamples({INVITATION_NOT_FOUND, INVALID_INPUT_VALUE, ITINERARY_NOT_FOUND})
+    @PostMapping("/{tripId}/itineraries/{itineraryId}/itineraryDetails/bulk")
+    public ApiResponse<List<ItineraryDetailsCreateResponse>> bulkCreateItineraryDetails(
+            @PathVariable UUID tripId,
+            @PathVariable UUID itineraryId,
+            @Valid @RequestBody ItineraryDetailsBulkCreateRequest request) {
+        return ApiResponse.created(manageItineraryDetailsUseCase.bulkCreateItineraryDetails(tripId, itineraryId, request));
+    }
+
+    @Operation(summary = "하루 세부일정 전체 삭제", description = "해당 날짜(itinerary)의 세부일정을 모두 삭제. 일자 자체는 삭제되지 않음")
+    @ApiErrorCodeExamples({INVITATION_NOT_FOUND, ITINERARY_NOT_FOUND})
+    @DeleteMapping("/{tripId}/itineraries/{itineraryId}/itineraryDetails")
+    public ApiResponse<Void> deleteAllItineraryDetails(
+            @PathVariable UUID tripId,
+            @PathVariable UUID itineraryId) {
+        manageItineraryDetailsUseCase.deleteAllItineraryDetails(tripId, itineraryId);
+        return ApiResponse.noContent();
+    }
+
+    @Operation(summary = "세부일정 삭제")
     @ApiErrorCodeExample(INVITATION_NOT_FOUND)
     @DeleteMapping("/{tripId}/itineraries/{itineraryId}/itineraryDetails/{itineraryDetailsId}")
     public ApiResponse<Void> deleteItineraryDetail(
@@ -76,15 +91,27 @@ public class ItineraryController {
         return ApiResponse.noContent();
     }
 
-    @Operation(
-            summary = "여행 일정 목록 조회",
-            description = "여행 일정 목록 조회하는 API"
-    )
-    @GetMapping("/{tripId}/itineraries")
-    @Schema(description = "여행 일정 목록 조회")
-    public ApiResponse<Page<ItineraryResponse>> getItineraries(
-            @PathVariable UUID tripId, @PageableDefault(size = 10, page = 0) Pageable page) {
-        Page<ItineraryResponse> itineraries = getItinerariesUseCase.getItineraries(tripId, page);
-        return ApiResponse.ok(itineraries);
+    @Operation(summary = "세부일정 날짜 이동",
+            description = "세부일정을 다른 날짜(itinerary)로 이동. 원본 날짜의 sortOrder 재정렬 및 대상 날짜 맨 뒤에 추가")
+    @ApiErrorCodeExamples({INVITATION_NOT_FOUND, ENTITY_NOT_FOUND, ITINERARY_NOT_FOUND})
+    @PatchMapping("/{tripId}/itineraries/{itineraryId}/itineraryDetails/{itineraryDetailId}/move")
+    public ApiResponse<Void> moveItineraryDetail(
+            @PathVariable UUID tripId,
+            @PathVariable UUID itineraryId,
+            @PathVariable UUID itineraryDetailId,
+            @RequestBody ItineraryDetailMoveRequest request) {
+        manageItineraryDetailsUseCase.moveItineraryDetail(tripId, itineraryId, itineraryDetailId, request);
+        return ApiResponse.noContent();
+    }
+
+    @Operation(summary = "세부일정 순서 변경", description = "orderedIds 순서대로 sortOrder 재설정")
+    @ApiErrorCodeExamples({INVITATION_NOT_FOUND, ENTITY_NOT_FOUND, ITINERARY_NOT_FOUND})
+    @PatchMapping("/{tripId}/itineraries/{itineraryId}/itineraryDetails/order")
+    public ApiResponse<Void> reorderItineraryDetails(
+            @PathVariable UUID tripId,
+            @PathVariable UUID itineraryId,
+            @RequestBody ItineraryDetailReorderRequest request) {
+        manageItineraryDetailsUseCase.reorderItineraryDetails(tripId, itineraryId, request);
+        return ApiResponse.noContent();
     }
 }

--- a/src/main/java/com/retrip/trip/infra/adapter/out/persistence/mysql/query/TripItineraryQuerydslRepository.java
+++ b/src/main/java/com/retrip/trip/infra/adapter/out/persistence/mysql/query/TripItineraryQuerydslRepository.java
@@ -7,19 +7,16 @@ import com.retrip.trip.application.out.repository.TripItineraryQueryRepository;
 import com.retrip.trip.domain.entity.Itinerary;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.annotations.BatchSize;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 import static com.retrip.trip.domain.entity.QItinerary.itinerary;
 import static com.retrip.trip.domain.entity.QItineraryDetail.itineraryDetail;
-import static com.retrip.trip.domain.entity.QTrip.trip;
-import static com.retrip.trip.infra.adapter.util.PaginationUtils.checkEndPage;
 
 @RequiredArgsConstructor
 @Repository
@@ -39,9 +36,7 @@ public class TripItineraryQuerydslRepository implements TripItineraryQueryReposi
     }
 
     @Override
-    public Optional<Itinerary> findByIdWithItineraryDetail(
-            UUID itineraryId,
-            UUID itineraryDetailsId) {
+    public Optional<Itinerary> findByIdWithItineraryDetail(UUID itineraryId, UUID itineraryDetailsId) {
         return Optional.ofNullable(query
                 .selectFrom(itinerary)
                 .leftJoin(itineraryDetail)
@@ -52,8 +47,7 @@ public class TripItineraryQuerydslRepository implements TripItineraryQueryReposi
     }
 
     @Override
-    public Optional<Itinerary> findByIdWithItineraryDetails(
-            UUID itineraryId) {
+    public Optional<Itinerary> findByIdWithItineraryDetails(UUID itineraryId) {
         return Optional.ofNullable(query
                 .selectFrom(itinerary)
                 .leftJoin(itineraryDetail)
@@ -64,51 +58,34 @@ public class TripItineraryQuerydslRepository implements TripItineraryQueryReposi
     }
 
     @Override
-    public Page<ItineraryResponse> findItineraries(UUID tripId, Pageable page) {
-        List<Itinerary> result =
-                query.selectDistinct(itinerary)
-                        .from(itinerary)
-                        .leftJoin(itinerary.itineraryDetails.values, itineraryDetail)
-                        .where(itinerary.trip.id.eq(tripId))
-                        .offset(page.getOffset())
-                        .limit(page.getPageSize())
-                        .orderBy(itinerary.date.asc())
-                        .fetch();
+    public List<ItineraryResponse> findItineraries(UUID tripId) {
+        List<Itinerary> result = query.selectDistinct(itinerary)
+                .from(itinerary)
+                .leftJoin(itinerary.itineraryDetails.values, itineraryDetail)
+                .where(itinerary.trip.id.eq(tripId))
+                .orderBy(itinerary.date.asc())
+                .fetch();
 
-        // Transform 필요
-        List<ItineraryResponse> itineraries =
-                result.stream()
-                        .map(i ->
-                                new ItineraryResponse(
-                                        i.getId(),
-                                        i.getDate(),
-                                        i.getName(),
-                                        i.getItineraryDetails() != null
-                                                ? i
-                                                .getItineraryDetails()
-                                                .getValues()
-                                                .stream()
-                                                .map(
-                                                        id ->
-                                                                new ItineraryResponse
-                                                                        .ItineraryDetailResponse(
-                                                                        id.getId(),
-                                                                        id.getDescription().getValue(),
-                                                                        id.getTime().getValue(),
-                                                                        id.getPrice().getValue(),
-                                                                        id.getLocationId()
-                                                                )
-                                                )
-                                                .toList()
-                                                : new ArrayList<>()))
-                        .toList();
-
-        return checkEndPage(page, itineraries);
-    }
-
-
-    private static BooleanExpression tripEq(UUID tripId) {
-        return trip.id.eq(tripId);
+        return result.stream()
+                .map(i -> new ItineraryResponse(
+                        i.getId(),
+                        i.getDate(),
+                        i.getName(),
+                        i.getItineraryDetails() != null
+                                ? i.getItineraryDetails().getValues().stream()
+                                        .sorted(Comparator.comparingInt(d -> d.getSortOrder()))
+                                        .map(d -> new ItineraryResponse.ItineraryDetailResponse(
+                                                d.getId(),
+                                                d.getLocationId(),
+                                                null, // TODO: map service API 호출하여 locationId → locationName 조회
+                                                d.getTimeValue(),
+                                                d.getMemoValue(),
+                                                d.getSortOrder()
+                                        ))
+                                        .toList()
+                                : new ArrayList<>()
+                ))
+                .toList();
     }
 
     private static BooleanExpression itineraryEq(UUID itineraryId) {
@@ -118,5 +95,4 @@ public class TripItineraryQuerydslRepository implements TripItineraryQueryReposi
     private static BooleanExpression itineraryDetailEq(UUID itineraryDetailsId) {
         return itineraryDetail.id.eq(itineraryDetailsId);
     }
-
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,7 +21,7 @@ spring:
     hibernate:
       ddl-auto: create-drop
     open-in-view: false
-    defer-datasource-initialization: true
+    defer-datasource-initialization: false
 
 logging:
   level:

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -20,8 +20,8 @@ INSERT INTO itinerary (id, trip_id, name, date, created_at)
 VALUES (x'22222222222222222222222222222224', x'11111111111111111111111111111112', '3일차 서초 정복', '2026-03-03', now());
 
 -- 4. Itinerary Detail (상세 일정)
-INSERT INTO itinerary_detail (id, itinerary_id, description, time, price, created_at)
-VALUES (random_uuid(), x'22222222222222222222222222222222', '점심 식사 (마라탕)', '2026-03-01 12:00:00', 15000, now());
+INSERT INTO itinerary_detail (id, itinerary_id, description, time, sort_order, created_at)
+VALUES (random_uuid(), x'22222222222222222222222222222222', '점심 식사 (마라탕)', '2026-03-01 12:00:00', 0, now());
 
 -- 5. Trip Hash Tag (해시태그)
 INSERT INTO trip_hash_tag (id, trip_id, name, created_at)
@@ -44,14 +44,13 @@ VALUES (random_uuid(), x'11111111111111111111111111111111', x'999999999999999999
 
 -- 방장(HOST) 데이터
 INSERT INTO trip_participant (id, trip_id, member_id, status, role, created_at)
-VALUES (random_uuid(), x'11111111111111111111111111111111', x'99999999999999999999999999999993', 1, 'LEADER', now());
+VALUES (random_uuid(), x'11111111111111111111111111111111', x'99999999999999999999999999999993', 1, 'HOST', now());
 
 -- 일반 참여자(MEMBER) 데이터 (Member ID를 다르게 설정)
 INSERT INTO trip_participant (id, trip_id, member_id, status, role, created_at)
-VALUES (random_uuid(), x'11111111111111111111111111111112', x'99999999999999999999999999999991', 1, 'LEADER', now());
+VALUES (random_uuid(), x'11111111111111111111111111111112', x'99999999999999999999999999999991', 1, 'HOST', now());
 INSERT INTO trip_participant (id, trip_id, member_id, status, role, created_at)
-VALUES (random_uuid(), x'11111111111111111111111111111112', x'99999999999999999999999999999992', 1, 'PARTICIPANT',
-        now());
+VALUES (random_uuid(), x'11111111111111111111111111111112', x'99999999999999999999999999999992', 1, 'MEMBER', now());
 
 -- 7. Vote (투표 생성)
 INSERT INTO vote (id, trip_id, title, description, status, version, max_selections, anonymous, allow_add_option,

--- a/src/test/java/com/retrip/trip/application/in/ItineraryServiceTest.java
+++ b/src/test/java/com/retrip/trip/application/in/ItineraryServiceTest.java
@@ -1,26 +1,27 @@
 package com.retrip.trip.application.in;
 
 import com.retrip.trip.application.in.base.BaseItineraryServiceTest;
-import com.retrip.trip.application.in.request.ItineraryDetailsCreateRequest;
+import com.retrip.trip.application.in.request.ItineraryDetailMoveRequest;
+import com.retrip.trip.application.in.request.ItineraryDetailReorderRequest;
+import com.retrip.trip.application.in.request.ItineraryDetailsBulkCreateRequest;
 import com.retrip.trip.application.in.request.ItineraryDetailsUpdateRequest;
 import com.retrip.trip.application.in.request.ItineraryRequestFixture;
 import com.retrip.trip.application.in.response.ItineraryDetailsCreateResponse;
 import com.retrip.trip.application.in.response.ItineraryDetailsUpdateResponse;
 import com.retrip.trip.application.in.response.ItineraryResponse;
 import com.retrip.trip.domain.entity.Itinerary;
+import com.retrip.trip.domain.entity.ItineraryDetail;
 import com.retrip.trip.domain.entity.Trip;
-import com.retrip.trip.domain.exception.common.InvalidValueException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Comparator;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 public class ItineraryServiceTest extends BaseItineraryServiceTest {
@@ -28,103 +29,286 @@ public class ItineraryServiceTest extends BaseItineraryServiceTest {
     @Test
     @DisplayName("여행의 상세 일정을 생성 한다.")
     void createItineraryDetails() {
+        //given
         Trip saveTrip = tripRepository.save(trip);
-
         Itinerary itinerary = saveTrip.getItineraries().getValues().getFirst();
-        LocalDateTime time = trip.getItineraries().getValues().getFirst().getDate().atTime(LocalTime.now());
-        ItineraryDetailsCreateRequest request = ItineraryRequestFixture.createItineraryDetails(time, "속초 만석 닭강정", 20000L, locationId);
 
-        ItineraryDetailsCreateResponse response = itineraryService.createItineraryDetails(saveTrip.getId(), itinerary.getId(), request);
+        //when
+        ItineraryDetailsCreateResponse response = itineraryService.createItineraryDetails(
+                saveTrip.getId(), itinerary.getId(), ItineraryRequestFixture.createItineraryDetails(locationId));
 
-        assertThat(response.description()).isEqualTo("속초 만석 닭강정");
-        assertThat(response.price()).isEqualTo(20000L);
-        assertThat(response.time()).isEqualTo(LocalDateTime.now().plusDays(1).truncatedTo(ChronoUnit.HOURS));
+        //then
+        assertThat(response.locationId()).isEqualTo(locationId);
+        assertThat(response.time()).isNull();
+        assertThat(response.memo()).isNull();
+        assertThat(response.sortOrder()).isEqualTo(0);
     }
 
-
     @Test
-    @DisplayName("여행의 상세 일정을 수정 한다.")
+    @DisplayName("세부일정 시간과 메모를 수정 한다.")
     void updateItineraryDetails() {
+        //given
         Trip saveTrip = tripRepository.save(trip);
-
         Itinerary itinerary = saveTrip.getItineraries().getValues().getFirst();
-        LocalDateTime time1 = trip.getItineraries().getValues().getFirst().getDate().atTime(LocalTime.now());
-        LocalDateTime time2 = trip.getItineraries().getValues().getFirst().getDate().atTime(LocalTime.now()).plusHours(1);
-        LocalDateTime time3 = trip.getItineraries().getValues().getFirst().getDate().atTime(LocalTime.now()).plusHours(2);
-        ItineraryDetailsCreateRequest createRequest1 = ItineraryRequestFixture.createItineraryDetails(time1, "속초 만석 닭강정", 20000L, locationId);
-        ItineraryDetailsCreateRequest createRequest2 = ItineraryRequestFixture.createItineraryDetails(time2, "속초 바다", null, locationId);
 
-        ItineraryDetailsUpdateRequest updateRequest = ItineraryRequestFixture.updateItineraryDetails(time3, "속초 관람차", 10000L, locationId);
+        ItineraryDetailsCreateResponse createResponse = itineraryService.createItineraryDetails(
+                saveTrip.getId(), itinerary.getId(), ItineraryRequestFixture.createItineraryDetails(locationId));
 
-        ItineraryDetailsCreateResponse createResponse = itineraryService.createItineraryDetails(saveTrip.getId(), itinerary.getId(), createRequest1);
-        itineraryService.createItineraryDetails(saveTrip.getId(), itinerary.getId(), createRequest2);
+        LocalDateTime time = itinerary.getDate().atTime(LocalTime.now()).plusHours(2);
+        ItineraryDetailsUpdateRequest updateRequest = ItineraryRequestFixture.updateItineraryDetails(time, "속초 관람차", null);
 
-        ItineraryDetailsUpdateResponse response = itineraryService.updateItineraryDetails(saveTrip.getId(), itinerary.getId(), createResponse.id(), updateRequest);
+        //when
+        ItineraryDetailsUpdateResponse response = itineraryService.updateItineraryDetails(
+                saveTrip.getId(), itinerary.getId(), createResponse.id(), updateRequest);
 
-        assertThat(response.description()).isEqualTo("속초 관람차");
-        assertThat(response.price()).isEqualTo(10000L);
-        assertThat(response.time()).isEqualTo(LocalDateTime.now().plusDays(1).truncatedTo(ChronoUnit.HOURS).plusHours(2));
+        //then
+        assertThat(response.memo()).isEqualTo("속초 관람차");
+        assertThat(response.time()).isEqualTo(time.truncatedTo(ChronoUnit.HOURS));
     }
-
-    @Test
-    @DisplayName("여행의 중복된 상세 일정으로 수정할 수 없다..")
-    void canNotUpdateItineraryDetailsConflicting() {
-        Trip saveTrip = tripRepository.save(trip);
-
-        Itinerary itinerary = saveTrip.getItineraries().getValues().getFirst();
-        LocalDateTime time1 = trip.getItineraries().getValues().getFirst().getDate().atTime(LocalTime.now());
-        LocalDateTime time2 = trip.getItineraries().getValues().getFirst().getDate().atTime(LocalTime.now()).plusHours(1);
-        LocalDateTime time3 = trip.getItineraries().getValues().getFirst().getDate().atTime(LocalTime.now());
-        ItineraryDetailsCreateRequest createRequest1 = ItineraryRequestFixture.createItineraryDetails(time1, "속초 만석 닭강정", 20000L, locationId);
-        ItineraryDetailsCreateRequest createRequest2 = ItineraryRequestFixture.createItineraryDetails(time2, "속초 바다", null, locationId);
-        ItineraryDetailsUpdateRequest updateRequest = ItineraryRequestFixture.updateItineraryDetails(time3, "속초 관람차", 10000L, locationId);
-
-        itineraryService.createItineraryDetails(saveTrip.getId(), itinerary.getId(), createRequest1);
-        ItineraryDetailsCreateResponse createResponse = itineraryService.createItineraryDetails(saveTrip.getId(), itinerary.getId(), createRequest2);
-
-        assertThatThrownBy(() -> itineraryService.updateItineraryDetails(saveTrip.getId(), itinerary.getId(), createResponse.id(), updateRequest))
-                .isExactlyInstanceOf(InvalidValueException.class);
-    }
-
 
     @Test
     @DisplayName("여행의 일정 상세를 제거 한다.")
     void deleteItineraryDetails() {
+        //given
         Trip saveTrip = tripRepository.save(trip);
-
         Itinerary itinerary = saveTrip.getItineraries().getValues().getFirst();
-        LocalDateTime time = trip.getItineraries().getValues().getFirst().getDate().atTime(LocalTime.now());
-        ItineraryDetailsCreateRequest createRequest = ItineraryRequestFixture.createItineraryDetails(time, "속초 만석 닭강정", 20000L, locationId);
-        ItineraryDetailsCreateResponse createResponse = itineraryService.createItineraryDetails(saveTrip.getId(), itinerary.getId(), createRequest);
 
-        //
-        assertDoesNotThrow(() -> itineraryService.deleteItineraryDetail(saveTrip.getId(), itinerary.getId(), createResponse.id()));
+        //when
+        ItineraryDetailsCreateResponse createResponse = itineraryService.createItineraryDetails(
+                saveTrip.getId(), itinerary.getId(), ItineraryRequestFixture.createItineraryDetails(locationId));
+
+        //then
+        assertDoesNotThrow(() -> itineraryService.deleteItineraryDetail(
+                saveTrip.getId(), itinerary.getId(), createResponse.id()));
     }
 
-    @DisplayName("여행 일정을 조회한다.")
     @Test
-    void getItineraries() {
+    @DisplayName("세부일정의 순서를 변경 한다.")
+    void reorderItineraryDetails() {
+        //given
         Trip saveTrip = tripRepository.save(trip);
+        Itinerary itinerary = saveTrip.getItineraries().getValues().getFirst();
 
-        LocalDateTime time1 = trip.getItineraries().getValues().getFirst().getDate().atTime(LocalTime.now());
-        LocalDateTime time2 = trip.getItineraries().getValues().getFirst().getDate().atTime(LocalTime.now()).plusHours(1);
-        LocalDateTime time3 = trip.getItineraries().getValues().getLast().getDate().atTime(LocalTime.now());
-        ItineraryDetailsCreateRequest createRequest1 = ItineraryRequestFixture.createItineraryDetails(time1, "속초 만석 닭강정", 20000L, locationId);
-        ItineraryDetailsCreateRequest createRequest2 = ItineraryRequestFixture.createItineraryDetails(time2, "속초 바다", null, locationId);
-        ItineraryDetailsCreateRequest createRequest3 = ItineraryRequestFixture.createItineraryDetails(time3, "집가자", null, locationId);
+        ItineraryDetailsCreateResponse first = itineraryService.createItineraryDetails(
+                saveTrip.getId(), itinerary.getId(), ItineraryRequestFixture.createItineraryDetails(locationId));
+        ItineraryDetailsCreateResponse second = itineraryService.createItineraryDetails(
+                saveTrip.getId(), itinerary.getId(), ItineraryRequestFixture.createItineraryDetails(locationId));
 
+        //when
+        itineraryService.reorderItineraryDetails(saveTrip.getId(), itinerary.getId(),
+                new ItineraryDetailReorderRequest(List.of(second.id(), first.id())));
+
+        //then
+        Itinerary reloaded = tripItineraryQueryRepository.findByIdWithItineraryDetails(itinerary.getId()).orElseThrow();
+        assertThat(reloaded.getItineraryDetails().getValues().stream()
+                .filter(d -> d.getId().equals(second.id()))
+                .findFirst().orElseThrow().getSortOrder()).isEqualTo(0);
+        assertThat(reloaded.getItineraryDetails().getValues().stream()
+                .filter(d -> d.getId().equals(first.id()))
+                .findFirst().orElseThrow().getSortOrder()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("세부일정을 다른 날짜 맨 뒤로 이동한다.")
+    void moveItineraryDetailToLast() {
+        //given
+        Trip saveTrip = tripRepository.save(trip);
         Itinerary firstItinerary = saveTrip.getItineraries().getValues().getFirst();
         Itinerary lastItinerary = saveTrip.getItineraries().getValues().getLast();
 
-        itineraryService.createItineraryDetails(saveTrip.getId(), firstItinerary.getId(), createRequest2);
-        itineraryService.createItineraryDetails(saveTrip.getId(), firstItinerary.getId(), createRequest1);
-        itineraryService.createItineraryDetails(saveTrip.getId(), lastItinerary.getId(), createRequest3);
+        // target에 미리 2개 추가
+        itineraryService.createItineraryDetails(saveTrip.getId(), lastItinerary.getId(),
+                ItineraryRequestFixture.createItineraryDetails(locationId)); // sortOrder 0
+        itineraryService.createItineraryDetails(saveTrip.getId(), lastItinerary.getId(),
+                ItineraryRequestFixture.createItineraryDetails(locationId)); // sortOrder 1
 
-        Page<ItineraryResponse> searchItineraryResponses =
-                itineraryService.getItineraries(trip.getId(), PageRequest.of(0, 10));
+        ItineraryDetailsCreateResponse toMove = itineraryService.createItineraryDetails(
+                saveTrip.getId(), firstItinerary.getId(), ItineraryRequestFixture.createItineraryDetails(locationId));
 
-        assertThat(searchItineraryResponses.getTotalElements()).isEqualTo(10L);
-        assertThat(searchItineraryResponses.getPageable().getOffset()).isEqualTo(0);
-        assertThat(searchItineraryResponses.getPageable().getPageSize()).isEqualTo(10);
+        //when
+        // target 맨 뒤(sortOrder=2)로 이동
+        itineraryService.moveItineraryDetail(saveTrip.getId(), firstItinerary.getId(), toMove.id(),
+                new ItineraryDetailMoveRequest(lastItinerary.getId(), 2));
+
+        //then
+        Itinerary reloadedSource = tripItineraryQueryRepository.findByIdWithItineraryDetails(firstItinerary.getId()).orElseThrow();
+        Itinerary reloadedTarget = tripItineraryQueryRepository.findByIdWithItineraryDetails(lastItinerary.getId()).orElseThrow();
+
+        assertThat(reloadedSource.getItineraryDetails().getValues()).isEmpty();
+        assertThat(reloadedTarget.getItineraryDetails().getValues()).hasSize(3);
+
+        List<ItineraryDetail> sorted = reloadedTarget.getItineraryDetails().getValues().stream()
+                .sorted(Comparator.comparingInt(ItineraryDetail::getSortOrder))
+                .toList();
+        assertThat(sorted.getLast().getId()).isEqualTo(toMove.id());
+        assertThat(sorted.getLast().getSortOrder()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("세부일정을 다른 날짜 중간에 끼워 넣는다.")
+    void moveItineraryDetailToMiddle() {
+        //given
+        Trip saveTrip = tripRepository.save(trip);
+        Itinerary firstItinerary = saveTrip.getItineraries().getValues().getFirst();
+        Itinerary lastItinerary = saveTrip.getItineraries().getValues().getLast();
+
+        // target에 A(0), B(1), C(2) 추가
+        ItineraryDetailsCreateResponse detailA = itineraryService.createItineraryDetails(
+                saveTrip.getId(), lastItinerary.getId(), ItineraryRequestFixture.createItineraryDetails(locationId));
+        ItineraryDetailsCreateResponse detailB = itineraryService.createItineraryDetails(
+                saveTrip.getId(), lastItinerary.getId(), ItineraryRequestFixture.createItineraryDetails(locationId));
+        ItineraryDetailsCreateResponse detailC = itineraryService.createItineraryDetails(
+                saveTrip.getId(), lastItinerary.getId(), ItineraryRequestFixture.createItineraryDetails(locationId));
+
+        ItineraryDetailsCreateResponse toMove = itineraryService.createItineraryDetails(
+                saveTrip.getId(), firstItinerary.getId(), ItineraryRequestFixture.createItineraryDetails(locationId));
+
+        //when
+        // B(1) 위치에 끼워 넣기 → 결과: A(0), toMove(1), B(2), C(3)
+        itineraryService.moveItineraryDetail(saveTrip.getId(), firstItinerary.getId(), toMove.id(),
+                new ItineraryDetailMoveRequest(lastItinerary.getId(), 1));
+
+        //then
+        Itinerary reloadedTarget = tripItineraryQueryRepository.findByIdWithItineraryDetails(lastItinerary.getId()).orElseThrow();
+        List<ItineraryDetail> sorted = reloadedTarget.getItineraryDetails().getValues().stream()
+                .sorted(Comparator.comparingInt(ItineraryDetail::getSortOrder))
+                .toList();
+
+        assertThat(sorted).hasSize(4);
+        assertThat(sorted.get(0).getId()).isEqualTo(detailA.id());
+        assertThat(sorted.get(1).getId()).isEqualTo(toMove.id());
+        assertThat(sorted.get(2).getId()).isEqualTo(detailB.id());
+        assertThat(sorted.get(3).getId()).isEqualTo(detailC.id());
+    }
+
+    @Test
+    @DisplayName("하루 세부일정 전체를 일괄 생성하며 sortOrder가 순서대로 부여된다.")
+    void bulkCreateItineraryDetails() {
+        //given
+        Trip saveTrip = tripRepository.save(trip);
+        Itinerary itinerary = saveTrip.getItineraries().getValues().getFirst();
+
+        ItineraryDetailsBulkCreateRequest request = ItineraryRequestFixture.bulkCreateItineraryDetails(List.of(
+                ItineraryRequestFixture.bulkItem(locationId, "센소지", null),
+                ItineraryRequestFixture.bulkItem(locationId, "웨스트 긴자", null),
+                ItineraryRequestFixture.bulkItem(locationId, "도쿄 타워", null)
+        ));
+
+        //when
+        List<ItineraryDetailsCreateResponse> responses = itineraryService.bulkCreateItineraryDetails(
+                saveTrip.getId(), itinerary.getId(), request);
+
+        //then
+        assertThat(responses).hasSize(3);
+        assertThat(responses.get(0).sortOrder()).isEqualTo(0);
+        assertThat(responses.get(1).sortOrder()).isEqualTo(1);
+        assertThat(responses.get(2).sortOrder()).isEqualTo(2);
+        assertThat(responses.get(0).memo()).isEqualTo("센소지");
+        assertThat(responses.get(2).memo()).isEqualTo("도쿄 타워");
+    }
+
+    @Test
+    @DisplayName("기존 세부일정이 있을 때 일괄 생성 시 sortOrder가 기존 마지막 이후로 이어진다.")
+    void bulkCreateItineraryDetailsAppendsAfterExisting() {
+        //given
+        Trip saveTrip = tripRepository.save(trip);
+        Itinerary itinerary = saveTrip.getItineraries().getValues().getFirst();
+
+        itineraryService.createItineraryDetails(saveTrip.getId(), itinerary.getId(),
+                ItineraryRequestFixture.createItineraryDetails(locationId)); // sortOrder 0
+
+        ItineraryDetailsBulkCreateRequest request = ItineraryRequestFixture.bulkCreateItineraryDetails(List.of(
+                ItineraryRequestFixture.bulkItem(locationId, "복구항목A", null),
+                ItineraryRequestFixture.bulkItem(locationId, "복구항목B", null)
+        ));
+
+        //when
+        List<ItineraryDetailsCreateResponse> responses = itineraryService.bulkCreateItineraryDetails(
+                saveTrip.getId(), itinerary.getId(), request);
+
+        //then
+        assertThat(responses.get(0).sortOrder()).isEqualTo(1);
+        assertThat(responses.get(1).sortOrder()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("하루 세부일정을 전체 삭제하면 세부일정이 모두 제거되고 일자는 유지된다.")
+    void deleteAllItineraryDetails() {
+        //given
+        Trip saveTrip = tripRepository.save(trip);
+        Itinerary itinerary = saveTrip.getItineraries().getValues().getFirst();
+
+        itineraryService.createItineraryDetails(saveTrip.getId(), itinerary.getId(),
+                ItineraryRequestFixture.createItineraryDetails(locationId));
+        itineraryService.createItineraryDetails(saveTrip.getId(), itinerary.getId(),
+                ItineraryRequestFixture.createItineraryDetails(locationId));
+
+        //when
+        itineraryService.deleteAllItineraryDetails(saveTrip.getId(), itinerary.getId());
+
+        //then
+        Itinerary reloaded = tripItineraryQueryRepository.findByIdWithItineraryDetails(itinerary.getId()).orElseThrow();
+        assertThat(reloaded.getItineraryDetails().getValues()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("하루 일정 삭제 후 일괄 생성으로 복구하면 원래 순서가 유지된다.")
+    void deleteAllAndBulkCreateRestoresOriginalOrder() {
+        //given
+        Trip saveTrip = tripRepository.save(trip);
+        Itinerary itinerary = saveTrip.getItineraries().getValues().getFirst();
+
+        List<ItineraryDetailsCreateResponse> original = List.of(
+                itineraryService.createItineraryDetails(saveTrip.getId(), itinerary.getId(),
+                        ItineraryRequestFixture.createItineraryDetails(locationId)),
+                itineraryService.createItineraryDetails(saveTrip.getId(), itinerary.getId(),
+                        ItineraryRequestFixture.createItineraryDetails(locationId)),
+                itineraryService.createItineraryDetails(saveTrip.getId(), itinerary.getId(),
+                        ItineraryRequestFixture.createItineraryDetails(locationId))
+        );
+
+        itineraryService.deleteAllItineraryDetails(saveTrip.getId(), itinerary.getId());
+
+        // 프론트가 메모리에 보관해둔 데이터로 복구 요청
+        ItineraryDetailsBulkCreateRequest restoreRequest = ItineraryRequestFixture.bulkCreateItineraryDetails(
+                original.stream()
+                        .map(r -> ItineraryRequestFixture.bulkItem(r.locationId(), r.memo(), r.time()))
+                        .toList()
+        );
+
+        //when
+        List<ItineraryDetailsCreateResponse> restored = itineraryService.bulkCreateItineraryDetails(
+                saveTrip.getId(), itinerary.getId(), restoreRequest);
+
+        //then
+        assertThat(restored).hasSize(3);
+        assertThat(restored.get(0).sortOrder()).isEqualTo(0);
+        assertThat(restored.get(1).sortOrder()).isEqualTo(1);
+        assertThat(restored.get(2).sortOrder()).isEqualTo(2);
+        assertThat(restored.stream().map(ItineraryDetailsCreateResponse::locationId).toList())
+                .containsExactlyElementsOf(original.stream().map(ItineraryDetailsCreateResponse::locationId).toList());
+    }
+
+    @Test
+    @DisplayName("여행 일정을 조회한다.")
+    void getItineraries() {
+        //given
+        Trip saveTrip = tripRepository.save(trip);
+        Itinerary firstItinerary = saveTrip.getItineraries().getValues().getFirst();
+        Itinerary lastItinerary = saveTrip.getItineraries().getValues().getLast();
+
+        itineraryService.createItineraryDetails(saveTrip.getId(), firstItinerary.getId(),
+                ItineraryRequestFixture.createItineraryDetails(locationId));
+        itineraryService.createItineraryDetails(saveTrip.getId(), firstItinerary.getId(),
+                ItineraryRequestFixture.createItineraryDetails(locationId));
+        itineraryService.createItineraryDetails(saveTrip.getId(), lastItinerary.getId(),
+                ItineraryRequestFixture.createItineraryDetails(locationId));
+
+        //when
+        List<ItineraryResponse> result = itineraryService.getItineraries(saveTrip.getId());
+
+        //then
+        assertThat(result).isNotEmpty();
+        assertThat(result.getFirst().itineraryDetails()).hasSize(2);
     }
 }

--- a/src/test/java/com/retrip/trip/application/in/TripServiceTest.java
+++ b/src/test/java/com/retrip/trip/application/in/TripServiceTest.java
@@ -107,10 +107,10 @@ class TripServiceTest extends BaseTripServiceTest {
                         hashTags,
                         TripCategory.DOMESTIC);
 
-        // then
+        // when
         TripCreateResponse response = tripService.createTrip(memberId, request);
 
-        // when
+        // then
         assertThat(response.id()).isNotNull();
         assertThat(response.destinationIds()).hasSize(2);
         assertThat(response.destinationIds()).contains(locationId);

--- a/src/test/java/com/retrip/trip/application/in/request/ItineraryRequestFixture.java
+++ b/src/test/java/com/retrip/trip/application/in/request/ItineraryRequestFixture.java
@@ -1,15 +1,24 @@
 package com.retrip.trip.application.in.request;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 public class ItineraryRequestFixture {
 
-    public static ItineraryDetailsCreateRequest createItineraryDetails(LocalDateTime time, String description, Long price, UUID locationId) {
-        return new ItineraryDetailsCreateRequest(time, description, price, locationId);
+    public static ItineraryDetailsCreateRequest createItineraryDetails(UUID locationId) {
+        return new ItineraryDetailsCreateRequest(locationId);
     }
 
-    public static ItineraryDetailsUpdateRequest updateItineraryDetails(LocalDateTime time, String description, Long price, UUID locationId) {
-        return new ItineraryDetailsUpdateRequest(time, description, price, locationId);
+    public static ItineraryDetailsUpdateRequest updateItineraryDetails(LocalDateTime time, String memo, UUID locationId) {
+        return new ItineraryDetailsUpdateRequest(time, memo, locationId);
+    }
+
+    public static ItineraryDetailsBulkCreateRequest bulkCreateItineraryDetails(List<ItineraryDetailsBulkCreateRequest.Item> items) {
+        return new ItineraryDetailsBulkCreateRequest(items);
+    }
+
+    public static ItineraryDetailsBulkCreateRequest.Item bulkItem(UUID locationId, String memo, LocalDateTime time) {
+        return new ItineraryDetailsBulkCreateRequest.Item(locationId, memo, time);
     }
 }

--- a/src/test/java/com/retrip/trip/domain/entity/ItineraryDetailsTest.java
+++ b/src/test/java/com/retrip/trip/domain/entity/ItineraryDetailsTest.java
@@ -1,62 +1,122 @@
 package com.retrip.trip.domain.entity;
 
-import com.retrip.trip.domain.exception.common.InvalidValueException;
 import com.retrip.trip.domain.fixture.TripFixture;
 import com.retrip.trip.domain.vo.TripCategory;
-import com.retrip.trip.domain.vo.TripDescription;
 import com.retrip.trip.domain.vo.TripPeriod;
-import com.retrip.trip.domain.vo.TripTitle;
 
-import java.util.List;
-
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
 import java.util.UUID;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class ItineraryDetailsTest {
     UUID memberId = UUID.fromString("c076d246-7e6d-4191-bf5c-310aebf4c003");
     UUID locationId = UUID.fromString("13c8ab91-76bc-4f70-93e9-89f1a65dc64a");
+    Trip trip;
+    Itinerary itinerary;
 
-    @DisplayName("여행 상세 일정은 여행 일정과 일정이 같아야 한다.")
-    @Test
-    void ItineraryDetailsDayIsEqualToItineraryDay() {
-        TripPeriod period = new TripPeriod(
-                LocalDate.now().plusDays(1),
-                LocalDate.now().plusDays(5));
-        Trip trip = TripFixture.createTestTripWithPeriod(memberId, "속초 여행 맴버 구함", "속초 여행은 이렇게이렇게 갈겁니다~", TripCategory.DOMESTIC, period);
-
-        Itineraries itineraries = new Itineraries(trip, period);
-        Itinerary itinerary = itineraries.getValues().getFirst();
-        ItineraryDetail itineraryDetail
-                = ItineraryDetail.create(2000L, "속초 여행", LocalDateTime.now(), itinerary, locationId);
-
-        assertThatThrownBy(() -> itinerary.addItineraryDetail(itineraryDetail))
-                .isExactlyInstanceOf(InvalidValueException.class);
+    @BeforeEach
+    void setUp() {
+        trip = TripFixture.createTestTripWithPeriod(memberId, "속초 여행 맴버 구함", "속초 여행은 이렇게이렇게 갈겁니다~",
+                TripCategory.DOMESTIC, new TripPeriod(LocalDate.now().plusDays(1), LocalDate.now().plusDays(5)));
+        itinerary = trip.getItineraries().getValues().getFirst();
     }
 
-    @DisplayName("같은 시간에 상세 일정이 있으면 안된다.")
+    @DisplayName("세부일정 추가 시 sortOrder가 순서대로 부여된다.")
     @Test
-    void canNotItineraryDetailsTimeConflicting() {
-        TripPeriod period = new TripPeriod(
-                LocalDate.now().plusDays(1),
-                LocalDate.now().plusDays(5));
-        Trip trip = TripFixture.createTestTripWithPeriod(memberId, "속초 여행 맴버 구함", "속초 여행은 이렇게이렇게 갈겁니다~", TripCategory.DOMESTIC, period);
+    void addItineraryDetailAssignsSortOrder() {
+        ItineraryDetail detail1 = ItineraryDetail.create(null, null, itinerary, locationId, 0);
+        ItineraryDetail detail2 = ItineraryDetail.create(null, null, itinerary, locationId, 1);
+        itinerary.addItineraryDetail(detail1);
+        itinerary.addItineraryDetail(detail2);
 
-        Itineraries itineraries = new Itineraries(trip, period);
-        Itinerary itinerary = itineraries.getValues().getFirst();
-        ItineraryDetail itineraryDetail
-                = ItineraryDetail.create(2000L, "속초 여행", LocalDateTime.now().plusDays(1), itinerary, locationId);
-        itinerary.addItineraryDetail(itineraryDetail);
+        assertThat(itinerary.getItineraryDetails().getValues()).hasSize(2);
+        assertThat(detail1.getSortOrder()).isEqualTo(0);
+        assertThat(detail2.getSortOrder()).isEqualTo(1);
+    }
 
-        ItineraryDetail itineraryDetail2
-                = ItineraryDetail.create(2000L, "속초 여행", LocalDateTime.now().plusDays(1), itinerary, locationId);
+    @DisplayName("세부일정 삭제 후 남은 항목의 sortOrder가 재정렬된다.")
+    @Test
+    void removeItineraryDetailReordersSortOrder() {
+        ItineraryDetail detail1 = ItineraryDetail.create(null, null, itinerary, locationId, 0);
+        ItineraryDetail detail2 = ItineraryDetail.create(null, null, itinerary, locationId, 1);
+        ItineraryDetail detail3 = ItineraryDetail.create(null, null, itinerary, locationId, 2);
+        itinerary.addItineraryDetail(detail1);
+        itinerary.addItineraryDetail(detail2);
+        itinerary.addItineraryDetail(detail3);
 
-        assertThatThrownBy(() -> itinerary.addItineraryDetail(itineraryDetail2))
-                .isExactlyInstanceOf(InvalidValueException.class);
+        itinerary.removeItineraryDetail(detail1.getId());
+
+        List<ItineraryDetail> remaining = itinerary.getItineraryDetails().getValues();
+        assertThat(remaining).hasSize(2);
+        assertThat(remaining.stream().map(ItineraryDetail::getSortOrder).sorted().toList())
+                .containsExactly(0, 1);
+    }
+
+    @DisplayName("시간 없이도 세부일정을 추가할 수 있다.")
+    @Test
+    void addItineraryDetailWithoutTime() {
+        ItineraryDetail detail = ItineraryDetail.create(null, null, itinerary, locationId, 0);
+        itinerary.addItineraryDetail(detail);
+
+        assertThat(itinerary.getItineraryDetails().getValues()).hasSize(1);
+        assertThat(itinerary.getItineraryDetails().getValues().getFirst().getTimeValue()).isNull();
+    }
+
+    @DisplayName("다른 날짜의 시간을 가진 세부일정도 추가할 수 있다.")
+    @Test
+    void addItineraryDetailFromDifferentDate() {
+        ItineraryDetail detail = ItineraryDetail.create(null, LocalDateTime.now(), itinerary, locationId, 0);
+        itinerary.addItineraryDetail(detail);
+
+        assertThat(itinerary.getItineraryDetails().getValues()).hasSize(1);
+    }
+
+    @DisplayName("세부일정이 없는 상태에서 일괄 추가 시 sortOrder가 0부터 순서대로 부여된다.")
+    @Test
+    void addAllAssignsSortOrderFromZeroWhenEmpty() {
+        List<ItineraryDetail> details = List.of(
+                ItineraryDetail.create("메모1", null, itinerary, locationId, 0),
+                ItineraryDetail.create("메모2", null, itinerary, locationId, 0),
+                ItineraryDetail.create("메모3", null, itinerary, locationId, 0)
+        );
+
+        itinerary.addItineraryDetails(details);
+
+        List<ItineraryDetail> result = itinerary.getItineraryDetails().getValues().stream()
+                .sorted(Comparator.comparingInt(ItineraryDetail::getSortOrder))
+                .toList();
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).getSortOrder()).isEqualTo(0);
+        assertThat(result.get(1).getSortOrder()).isEqualTo(1);
+        assertThat(result.get(2).getSortOrder()).isEqualTo(2);
+    }
+
+    @DisplayName("기존 세부일정이 있을 때 일괄 추가 시 sortOrder가 기존 마지막 순서 이후로 이어진다.")
+    @Test
+    void addAllAppendsSortOrderAfterExistingDetails() {
+        itinerary.addItineraryDetail(ItineraryDetail.create(null, null, itinerary, locationId, 0)); // sortOrder 0
+        itinerary.addItineraryDetail(ItineraryDetail.create(null, null, itinerary, locationId, 1)); // sortOrder 1
+
+        List<ItineraryDetail> newDetails = List.of(
+                ItineraryDetail.create("복구A", null, itinerary, locationId, 0),
+                ItineraryDetail.create("복구B", null, itinerary, locationId, 0)
+        );
+
+        itinerary.addItineraryDetails(newDetails);
+
+        List<ItineraryDetail> result = itinerary.getItineraryDetails().getValues().stream()
+                .sorted(Comparator.comparingInt(ItineraryDetail::getSortOrder))
+                .toList();
+        assertThat(result).hasSize(4);
+        assertThat(newDetails.get(0).getSortOrder()).isEqualTo(2);
+        assertThat(newDetails.get(1).getSortOrder()).isEqualTo(3);
     }
 }


### PR DESCRIPTION
  ## 🔍 PR 타입 선택                                        
                                                                                                                                                                                
  - [x] `feat`: 새로운 기능 추가
  - [ ] `fix`: 버그 수정                                                                                                                                                        
  - [ ] `docs`: 문서 수정                                   
  - [ ] `style`: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우                                                                                                              
  - [ ] `refactor`: 코드 리팩토링
  - [ ] `test`: 테스트 코드 추가 또는 수정                                                                                                                                      
  - [ ] `chore`: 빌드 업무 수정, 패키지 매니저 수정 등 기타 작업                                                                                                                
   
                                                                                                                                                                                
  ## 📝 변경 사항 요약                                      
                                                                                                                                                                                
  - `ItineraryDetailDescription` → `ItineraryDetailMemo` 리네임, 최대 길이 100 → 200 변경                                                                                       
  - 세부일정 단건 CRUD, 날짜 이동, 순서 변경 API 구현
  - 하루 세부일정 전체 삭제 API 추가                                                                                                                                            
  - 세부일정 일괄 생성 API 추가 (실행취소 복구용)                                                                                                                               
  - 하루 일정 전체 삭제 및 복구 테스트 추가
                                                                                                                                                                                
                                                            
  ## 🛠 관련 이슈                                                                                                                                                                
                                                            
  close: #67                                                                                                                                                                    
   
                                                                                                                                                                                
  ### **추가 설명 (선택 사항)**                             

  **실행취소 설계 (클라이언트 메모리 방식)**                                                                                                                                    
   
  하루 일정 삭제 시 서버에 즉시 반영하고, 프론트가 삭제 전 데이터를 메모리에 보관.                                                                                              
  토스트의 "실행취소" 버튼 클릭 시 Bulk Create API로 원래 순서 그대로 복구.
                                                                                                                                                                                
  **추가된 API 목록**                                       
                                                                                                                                                                                
  | Method | URL | 설명 |                                                                                                                                                       
  |--------|-----|------|
  | GET | `/trips/{tripId}/itineraries` | 여행 일정 목록 조회 |                                                                                                                 
  | POST | `.../itineraryDetails` | 세부일정 단건 추가 |                                                                                                                        
  | PUT | `.../itineraryDetails/{id}` | 세부일정 수정 |
  | DELETE | `.../itineraryDetails/{id}` | 세부일정 단건 삭제 |                                                                                                                 
  | DELETE | `.../itineraryDetails` | 하루 세부일정 전체 삭제 |                                                                                                                 
  | POST | `.../itineraryDetails/bulk` | 세부일정 일괄 생성 (실행취소 복구) |                                                                                                   
  | PATCH | `.../itineraryDetails/{id}/move` | 세부일정 날짜 이동 |                                                                                                             
  | PATCH | `.../itineraryDetails/order` | 세부일정 순서 변경 |                                                                                                                 
                                                                                                                                                                                
  ---  